### PR TITLE
Feature/migrate to net 10

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,5 @@
+# .NET Core (ASDF)
+# Configuração local para este projeto
+# ASDF usará automaticamente .NET 10.0.102 ao entrar neste diretório
+
+dotnet-core 10.0.102

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## [Unreleased]
+
+### Changed
+- Migrated from .NET 9.0 to .NET 10.0 LTS
+- Updated YoutubeExplode from 6.5.4 to 6.5.6
+- Updated FFmpeg.AutoGen from 7.0.0 to 8.0.0
+- Configured ASDF .tool-versions for project-local .NET 10.0
+
+### Fixed
+- Improved error messages on Linux
+
+### Performance
+- Benefits from .NET 10 JIT improvements
+- Faster startup time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,9 @@
 ### Performance
 - Benefits from .NET 10 JIT improvements
 - Faster startup time
+
+### Known Issues
+- YoutubeExplode currently experiencing 403 Forbidden errors due to YouTube's new PO token requirement (Jan 2026)
+- Issue tracked at: https://github.com/Tyrrrz/YoutubeExplode/issues/933
+- Fix PR pending: https://github.com/Tyrrrz/YoutubeExplode/pull/934
+- This is NOT related to the .NET 10 migration

--- a/README.md
+++ b/README.md
@@ -29,14 +29,29 @@ Explorar funcionalidades de processos com FFMpeg.
 
 
 # Tecnologias
-- Dotnet 9.0
-- YoutubeExplode 6
-- FFMpeg 6
+- Dotnet 10.0 LTS (suporte até Nov 2028)
+- YoutubeExplode 6.5.6
+- FFmpeg.AutoGen 8.0.0
 
 
 # Requisitos para rodar
-- Dotnet +6.0 runtime
-- FFMpeg +6
+- .NET 10.0 runtime ou superior
+- FFmpeg 6+ (opcional para versões bundle)
+
+## Desenvolvimento
+
+Este projeto usa ASDF para gerenciar versões do .NET.
+
+```bash
+# Instalar ASDF
+git clone https://github.com/asdf-vm/asdf.git ~/.asdf
+
+# Instalar .NET 10.0
+asdf plugin add dotnet-core
+asdf install
+```
+
+O arquivo .tool-versions configura automaticamente o .NET 10.0 ao entrar no projeto.
 
 
 

--- a/cutube/cutube.csproj
+++ b/cutube/cutube.csproj
@@ -2,15 +2,15 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="FFmpeg.AutoGen" Version="7.0.0" />
-      <PackageReference Include="YoutubeExplode" Version="6.5.4" />
-      <PackageReference Include="YoutubeExplode.Converter" Version="6.5.4" />
+      <PackageReference Include="FFmpeg.AutoGen" Version="8.0.0" />
+      <PackageReference Include="YoutubeExplode" Version="6.5.6" />
+      <PackageReference Include="YoutubeExplode.Converter" Version="6.5.6" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Resumo do PR:
feat: migrate to .NET 10.0 LTS
✅ TargetFramework: net9.0 → net10.0
✅ YoutubeExplode: 6.5.4 → 6.5.6  
✅ FFmpeg.AutoGen: 7.0.0 → 8.0.0
✅ ASDF .tool-versions configurado
✅ Build: 0 warnings, 0 errors
✅ Migration plan: plans/migracao-dotnet-10.md
Branch: feature/migrate-to-net-10 → develop
