### PR TITLE
fix: remove yt-dlp update messages to avoid console interference

### DIFF
--- a/cutube/YtDlpHelper.cs
+++ b/cutube/YtDlpHelper.cs
@@ -198,9 +198,7 @@ public class YtDlpHelper : IYtDlpService, IDisposable
                 return;
             }
 
-            _consoleService.WriteLine($"Atualizando yt-dlp: {currentVersion} → {latestVersion}");
             await DownloadLatestVersion(_userPath);
-            _consoleService.WriteLine("✓ yt-dlp atualizado com sucesso!");
             
             // Atualizar referência
             _ytdl = new YoutubeDL { YoutubeDLPath = _userPath };


### PR DESCRIPTION
Problema: Mensagens de atualização do yt-dlp apareciam durante o input do usuário (Task.Run em background).
Solução: Removi as mensagens de "Atualizando..." e "✓ yt-dlp atualizado" do YtDlpHelper.cs:201-203
Resultados:
- ✓ Todos 111 testes passando
- ✓ Build sem warnings
- ✓ Commit criado: fix/remove-update-messages