### PR TITLE
feat(auth): integrate auth pages flow and dev tooling (magicko-es6.2)

### DIFF
--- a/cutube.sln
+++ b/cutube.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cutube.Tests", "tests\Cutube.Tests\Cutube.Tests.csproj", "{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cutube.Domain.Tests", "tests\Cutube.Domain.Tests\Cutube.Domain.Tests.csproj", "{2BC3A692-544B-4F58-8B70-5526A9193052}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,6 +61,18 @@ Global
 		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}.Release|x64.Build.0 = Release|Any CPU
 		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}.Release|x86.ActiveCfg = Release|Any CPU
 		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}.Release|x86.Build.0 = Release|Any CPU
+		{2BC3A692-544B-4F58-8B70-5526A9193052}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2BC3A692-544B-4F58-8B70-5526A9193052}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2BC3A692-544B-4F58-8B70-5526A9193052}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2BC3A692-544B-4F58-8B70-5526A9193052}.Debug|x64.Build.0 = Debug|Any CPU
+		{2BC3A692-544B-4F58-8B70-5526A9193052}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2BC3A692-544B-4F58-8B70-5526A9193052}.Debug|x86.Build.0 = Debug|Any CPU
+		{2BC3A692-544B-4F58-8B70-5526A9193052}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2BC3A692-544B-4F58-8B70-5526A9193052}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2BC3A692-544B-4F58-8B70-5526A9193052}.Release|x64.ActiveCfg = Release|Any CPU
+		{2BC3A692-544B-4F58-8B70-5526A9193052}.Release|x64.Build.0 = Release|Any CPU
+		{2BC3A692-544B-4F58-8B70-5526A9193052}.Release|x86.ActiveCfg = Release|Any CPU
+		{2BC3A692-544B-4F58-8B70-5526A9193052}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -66,5 +80,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{9DB707DF-7422-4BD0-ABE2-A1A0A1FC1E24} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{2BC3A692-544B-4F58-8B70-5526A9193052} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/cutube.sln
+++ b/cutube.sln
@@ -9,6 +9,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cutube.Domain", "src\Cutube.Domain\Cutube.Domain.csproj", "{9DB707DF-7422-4BD0-ABE2-A1A0A1FC1E24}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cutube.Tests", "tests\Cutube.Tests\Cutube.Tests.csproj", "{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,11 +47,24 @@ Global
 		{9DB707DF-7422-4BD0-ABE2-A1A0A1FC1E24}.Release|x64.Build.0 = Release|Any CPU
 		{9DB707DF-7422-4BD0-ABE2-A1A0A1FC1E24}.Release|x86.ActiveCfg = Release|Any CPU
 		{9DB707DF-7422-4BD0-ABE2-A1A0A1FC1E24}.Release|x86.Build.0 = Release|Any CPU
+		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}.Debug|x64.Build.0 = Debug|Any CPU
+		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}.Debug|x86.Build.0 = Debug|Any CPU
+		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}.Release|x64.ActiveCfg = Release|Any CPU
+		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}.Release|x64.Build.0 = Release|Any CPU
+		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}.Release|x86.ActiveCfg = Release|Any CPU
+		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{9DB707DF-7422-4BD0-ABE2-A1A0A1FC1E24} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{C8CEB6A3-75AF-46EF-AEAE-04490DE61A18} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/cutube/DomainWorkflow.cs
+++ b/cutube/DomainWorkflow.cs
@@ -1,0 +1,218 @@
+using System.Threading;
+using Cutube.Domain.Models;
+using Cutube.Domain.Services;
+using Cutube.ErrorHandling;
+using FluentResults;
+using CliResult = Cutube.ErrorHandling.Result;
+using CliResultT = Cutube.ErrorHandling.Result<string>;
+
+namespace cutube;
+
+/// <summary>
+/// Orchestrates the download workflow using Domain services
+/// </summary>
+public class DomainWorkflow : IDisposable
+{
+    private readonly IMenuService _menu;
+    private readonly IMetadataService _metadataService;
+    private readonly IDownloadService _downloadService;
+    private readonly IConsoleService _console;
+    private readonly IFileService _fileService;
+    private readonly CancellationToken _ct;
+
+    /// <summary>
+    /// Creates a new DomainWorkflow
+    /// </summary>
+    public DomainWorkflow(
+        IMenuService menu,
+        IMetadataService metadataService,
+        IDownloadService downloadService,
+        IConsoleService console,
+        IFileService fileService,
+        CancellationToken ct = default)
+    {
+        _menu = menu;
+        _metadataService = metadataService;
+        _downloadService = downloadService;
+        _console = console;
+        _fileService = fileService;
+        _ct = ct;
+    }
+
+    /// <summary>
+    /// Executes the download workflow
+    /// </summary>
+    public async Task<CliResult> RunAsync()
+    {
+        try
+        {
+            // Show menu and collect user input
+            var errorHandler = new DefaultErrorHandler();
+            var menuResult = _menu.Show(_console, _fileService, errorHandler);
+            if (!menuResult.IsSuccess)
+                return menuResult;
+
+            var videoUrl = _menu.Url;
+
+            _console.WriteLine("Obtendo informações do vídeo...");
+
+            // Get metadata using Domain service
+            var metadataResult = await _metadataService.GetMetadataAsync(videoUrl, _ct);
+            if (metadataResult.IsFailed)
+            {
+                _console.WriteLine($"❌ Erro ao obter metadados: {metadataResult.Errors.First().Message}");
+                return CliResult.Failure(ErrorType.Network, metadataResult.Errors.First().Message);
+            }
+
+            var metadata = metadataResult.Value;
+
+            // Determine filename
+            var fileName = string.IsNullOrWhiteSpace(_menu.CustomFileName)
+                ? metadata.Title
+                : TitleHelper.FormatTitle(_menu.CustomFileName);
+
+            // Get output directory
+            var outputDirResult = GetOutputDirectory();
+            if (outputDirResult.IsFailure)
+                return outputDirResult;
+
+            var outputDir = outputDirResult.Value;
+            var extension = _menu.AudioOnly ? ".mp3" : ".mp4";
+            var output = Path.Combine(outputDir, $"{fileName}{extension}");
+
+            // Build download request
+            var request = new DownloadRequest
+            {
+                Url = videoUrl,
+                OutputPath = output,
+                AudioOnly = _menu.AudioOnly,
+                TimeRange = BuildTimeRange()
+            };
+
+            // Execute download
+            return await DownloadVideoAsync(request);
+        }
+        catch (OperationCanceledException)
+        {
+            _console.WriteLine("\n⚠️  Operação cancelada pelo usuário.");
+            return CliResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _console.WriteLine($"Erro: {ex.Message}");
+            return CliResult.Failure(ErrorType.Critical, ex.Message, ex);
+        }
+    }
+
+    /// <summary>
+    /// Gets and validates the output directory
+    /// </summary>
+    private CliResultT GetOutputDirectory()
+    {
+        try
+        {
+            var outputDir = string.IsNullOrWhiteSpace(_menu.OutputDirectory)
+                ? Directory.GetCurrentDirectory()
+                : NormalizePath(_menu.OutputDirectory);
+
+            if (!_fileService.DirectoryExists(outputDir))
+            {
+                _console.WriteLine($"⚠️  Diretório '{outputDir}' não existe.");
+                _console.Write("Deseja criá-lo? (s/n): ");
+                var response = _console.ReadLine()?.ToLower();
+                if (response == "s")
+                {
+                    _fileService.CreateDirectory(outputDir);
+                    _console.WriteLine($"✓ Diretório criado: {outputDir}");
+                }
+                else
+                {
+                    _console.WriteLine("❌ Operação cancelada.");
+                    return CliResultT.Failure(ErrorType.Validation, "Operação cancelada pelo usuário");
+                }
+            }
+
+            ValidationHelper.ValidateDirectory(outputDir, _fileService);
+            return CliResultT.Success(outputDir);
+        }
+        catch (Exception ex)
+        {
+            return CliResultT.Failure(ErrorType.FileSystem, ex.Message, ex);
+        }
+    }
+
+    /// <summary>
+    /// Builds a TimeRange from menu input if provided
+    /// </summary>
+    private TimeRange? BuildTimeRange()
+    {
+        if (string.IsNullOrWhiteSpace(_menu.Start) || string.IsNullOrWhiteSpace(_menu.End))
+            return null;
+
+        return TimeRange.FromStrings(_menu.Start, _menu.End);
+    }
+
+    /// <summary>
+    /// Downloads video using Domain service
+    /// </summary>
+    private async Task<CliResult> DownloadVideoAsync(DownloadRequest request)
+    {
+        try
+        {
+            var typeLabelInicio = request.AudioOnly ? "áudio" : "vídeo";
+            _console.WriteLine($"Iniciando o download e corte do {typeLabelInicio}...");
+            _console.WriteLine("Esse processo pode demorar, aguarde...");
+
+            // Create progress reporter
+            var progress = new Progress<DownloadProgress>(p =>
+            {
+                if (p.Percentage > 0)
+                {
+                    var percentage = p.Percentage * 100;
+                    _console.WriteLine($"Progresso: {percentage:F0}%");
+                }
+
+                if (!string.IsNullOrEmpty(p.State) && p.State != "downloading")
+                {
+                    _console.WriteLine($"Estado: {p.State}");
+                }
+            });
+
+            // Execute download via Domain
+            var result = await _downloadService.DownloadAsync(request, progress, _ct);
+
+            if (result.IsFailed)
+            {
+                var errorMsg = result.Errors.First().Message;
+                _console.WriteLine($"❌ Erro no download: {errorMsg}");
+                return CliResult.Failure(ErrorType.Network, errorMsg);
+            }
+
+            var downloadResult = result.Value;
+            var typeLabel = request.AudioOnly ? "Áudio" : "Vídeo";
+            _console.WriteLine($"✓ {typeLabel} salvo em: {Path.GetFullPath(downloadResult.FilePath)}");
+
+            return CliResult.Success();
+        }
+        catch (Exception ex)
+        {
+            return CliResult.Failure(ErrorType.Network, ex.Message, ex);
+        }
+    }
+
+    /// <summary>
+    /// Normalizes a file path
+    /// </summary>
+    private string NormalizePath(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+        fullPath = fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return fullPath;
+    }
+
+    public void Dispose()
+    {
+        // Nothing to dispose currently
+        // Infrastructure services handle their own disposal
+    }
+}

--- a/cutube/Infrastructure/FfmpegProcessor.cs
+++ b/cutube/Infrastructure/FfmpegProcessor.cs
@@ -57,8 +57,6 @@ public class FfmpegProcessor : IVideoProcessor
             var durationRegex = new Regex(@"Duration: (\d+):(\d+):(\d+)\.(\d+)");
             var progressRegex = new Regex(@"time=(\d+):(\d+):(\d+)\.(\d+)");
 
-            var errorReader = taskStream: process.StandardError.ReadToEndAsync();
-
             // Read stderr line by line for progress
             var reader = process.StandardError;
             string? line;
@@ -105,10 +103,8 @@ public class FfmpegProcessor : IVideoProcessor
 
                         progress?.Report(new ProcessingProgress
                         {
-                            Percentage = percentage,
-                            CurrentTime = currentTime,
-                            TotalTime = duration,
-                            Speed = 1.0 // Would need to calculate from frame rate
+                            Percentage = (int)percentage,
+                            CurrentOperation = "Processing"
                         });
                     }
                 }
@@ -125,9 +121,10 @@ public class FfmpegProcessor : IVideoProcessor
             var fileInfo = new FileInfo(request.OutputPath);
             return new ProcessingResult
             {
+                Success = true,
                 OutputPath = request.OutputPath,
-                Size = fileInfo.Length,
-                Duration = duration
+                FileSizeBytes = fileInfo.Length,
+                ErrorMessage = null
             };
         }
         catch (OperationCanceledException)

--- a/cutube/Infrastructure/FfmpegProcessor.cs
+++ b/cutube/Infrastructure/FfmpegProcessor.cs
@@ -1,0 +1,168 @@
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Cutube.Domain.Interfaces;
+using Cutube.Domain.Models;
+
+namespace Cutube.Infrastructure;
+
+/// <summary>
+/// Processes videos using FFmpeg (cutting, audio extraction, format conversion)
+/// </summary>
+public class FfmpegProcessor : IVideoProcessor
+{
+    private readonly string _ffmpegPath;
+
+    /// <summary>
+    /// Initializes a new instance of FfmpegProcessor
+    /// </summary>
+    /// <param name="ffmpegPath">Path to ffmpeg executable (null to use system PATH)</param>
+    public FfmpegProcessor(string? ffmpegPath = null)
+    {
+        _ffmpegPath = ffmpegPath ?? "ffmpeg";
+    }
+
+    /// <inheritdoc/>
+    public async Task<ProcessingResult> ProcessAsync(
+        ProcessingRequest request,
+        IProgress<ProcessingProgress>? progress = null,
+        CancellationToken ct = default)
+    {
+        if (!File.Exists(request.InputPath))
+            throw new FileNotFoundException($"Input file not found: {request.InputPath}");
+
+        if (string.IsNullOrWhiteSpace(request.OutputPath))
+            throw new ArgumentException("Output path cannot be empty", nameof(request));
+
+        // Build FFmpeg arguments
+        var arguments = BuildArguments(request);
+
+        var processInfo = new ProcessStartInfo
+        {
+            FileName = _ffmpegPath,
+            Arguments = arguments,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = false
+        };
+
+        try
+        {
+            using var process = Process.Start(processInfo);
+            if (process == null)
+                throw new InvalidOperationException("Failed to start FFmpeg process");
+
+            // Parse progress from stderr
+            var duration = TimeSpan.Zero;
+            var durationRegex = new Regex(@"Duration: (\d+):(\d+):(\d+)\.(\d+)");
+            var progressRegex = new Regex(@"time=(\d+):(\d+):(\d+)\.(\d+)");
+
+            var errorReader = taskStream: process.StandardError.ReadToEndAsync();
+
+            // Read stderr line by line for progress
+            var reader = process.StandardError;
+            string? line;
+
+            while ((line = await reader.ReadLineAsync(ct)) != null)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    process.Kill(entireProcessTree: true);
+                    ct.ThrowIfCancellationRequested();
+                }
+
+                // Extract duration
+                if (line.Contains("Duration"))
+                {
+                    var match = durationRegex.Match(line);
+                    if (match.Success)
+                    {
+                        duration = new TimeSpan(
+                            0,
+                            int.Parse(match.Groups[1].Value),
+                            int.Parse(match.Groups[2].Value),
+                            int.Parse(match.Groups[3].Value),
+                            int.Parse(match.Groups[4].Value) * 10
+                        );
+                    }
+                }
+
+                // Extract progress
+                if (line.Contains("time="))
+                {
+                    var match = progressRegex.Match(line);
+                    if (match.Success && duration > TimeSpan.Zero)
+                    {
+                        var currentTime = new TimeSpan(
+                            0,
+                            int.Parse(match.Groups[1].Value),
+                            int.Parse(match.Groups[2].Value),
+                            int.Parse(match.Groups[3].Value),
+                            int.Parse(match.Groups[4].Value) * 10
+                        );
+
+                        var percentage = (currentTime.TotalMilliseconds / duration.TotalMilliseconds) * 100;
+
+                        progress?.Report(new ProcessingProgress
+                        {
+                            Percentage = percentage,
+                            CurrentTime = currentTime,
+                            TotalTime = duration,
+                            Speed = 1.0 // Would need to calculate from frame rate
+                        });
+                    }
+                }
+            }
+
+            await process.WaitForExitAsync(ct);
+
+            if (process.ExitCode != 0)
+            {
+                throw new InvalidOperationException($"FFmpeg failed with exit code {process.ExitCode}");
+            }
+
+            // Get output file info
+            var fileInfo = new FileInfo(request.OutputPath);
+            return new ProcessingResult
+            {
+                OutputPath = request.OutputPath,
+                Size = fileInfo.Length,
+                Duration = duration
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"FFmpeg processing failed: {ex.Message}", ex);
+        }
+    }
+
+    private string BuildArguments(ProcessingRequest request)
+    {
+        var args = new List<string>();
+
+        // Input file
+        args.Add("-i");
+        args.Add($"\"{request.InputPath}\"");
+
+        // Time range
+        if (request.TimeRange != null)
+        {
+            args.Add("-ss");
+            args.Add(request.TimeRange.StartSeconds.ToString());
+            args.Add("-to");
+            args.Add(request.TimeRange.EndSeconds.ToString());
+        }
+
+        // Overwrite output file without asking
+        args.Add("-y");
+
+        // Output file
+        args.Add($"\"{request.OutputPath}\"");
+
+        return string.Join(" ", args);
+    }
+}

--- a/cutube/Infrastructure/FfmpegProcessor.cs
+++ b/cutube/Infrastructure/FfmpegProcessor.cs
@@ -141,6 +141,9 @@ public class FfmpegProcessor : IVideoProcessor
     {
         var args = new List<string>();
 
+        // Overwrite output file without asking (before input to avoid prompts)
+        args.Add("-y");
+
         // Input file
         args.Add("-i");
         args.Add($"\"{request.InputPath}\"");
@@ -154,8 +157,32 @@ public class FfmpegProcessor : IVideoProcessor
             args.Add(request.TimeRange.EndSeconds.ToString());
         }
 
-        // Overwrite output file without asking
-        args.Add("-y");
+        // Codec and format settings
+        if (request.AudioOnly)
+        {
+            // Audio extraction: no video, MP3 with high quality
+            args.Add("-vn");
+            args.Add("-c:a");
+            args.Add("libmp3lame");
+            args.Add("-q:a");
+            args.Add("2");
+        }
+        else
+        {
+            // Video: copy streams when possible (fast), re-encode if cutting
+            if (request.TimeRange != null)
+            {
+                args.Add("-c:v");
+                args.Add("libx264");
+                args.Add("-c:a");
+                args.Add("aac");
+            }
+            else
+            {
+                args.Add("-c");
+                args.Add("copy");
+            }
+        }
 
         // Output file
         args.Add($"\"{request.OutputPath}\"");

--- a/cutube/Infrastructure/FileSystem.cs
+++ b/cutube/Infrastructure/FileSystem.cs
@@ -1,0 +1,115 @@
+using Cutube.Domain.Interfaces;
+
+namespace Cutube.Infrastructure;
+
+/// <summary>
+/// Default implementation of IFileSystem using System.IO
+/// </summary>
+public class FileSystem : IFileSystem
+{
+    /// <inheritdoc/>
+    public bool Exists(string path)
+    {
+        try
+        {
+            return File.Exists(path);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Delete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // Silently fail if file doesn't exist
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task WriteAllBytesAsync(string path, byte[] data)
+    {
+        try
+        {
+            File.WriteAllBytes(path, data);
+            return Task.CompletedTask;
+        }
+        catch
+        {
+            return Task.FromException(new IOException($"Failed to write to {path}"));
+        }
+    }
+
+    /// <inheritdoc/>
+    public DateTime GetLastWriteTime(string path)
+    {
+        try
+        {
+            return File.GetLastWriteTime(path);
+        }
+        catch
+        {
+            return DateTime.MinValue;
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool DirectoryExists(string path)
+    {
+        try
+        {
+            return Directory.Exists(path);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool HasWritePermission(string path)
+    {
+        try
+        {
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
+
+            var testFile = Path.Combine(path, Guid.NewGuid().ToString());
+            File.WriteAllText(testFile, "test");
+            File.Delete(testFile);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void CreateDirectory(string path)
+    {
+        try
+        {
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
+        }
+        catch
+        {
+            // Silently fail if directory already exists
+        }
+    }
+}

--- a/cutube/Infrastructure/YtDlpDownloader.cs
+++ b/cutube/Infrastructure/YtDlpDownloader.cs
@@ -16,12 +16,24 @@ public class YtDlpDownloader : IVideoDownloader
     private readonly string _ytDlpPath;
 
     /// <summary>
-    /// Initializes a new instance of YtDlpDownloader
+    /// Initializes a new instance of YtDlpDownloader using auto-resolved yt-dlp path
     /// </summary>
-    /// <param name="ytDlpPath">Path to yt-dlp executable (null to use system PATH)</param>
-    public YtDlpDownloader(string? ytDlpPath = null)
+    public YtDlpDownloader()
     {
-        _ytDlpPath = ytDlpPath ?? "yt-dlp";
+        _ytDlpPath = YtDlpPathResolver.Resolve();
+        _ytdl = new YoutubeDL
+        {
+            YoutubeDLPath = _ytDlpPath
+        };
+    }
+
+    /// <summary>
+    /// Initializes a new instance of YtDlpDownloader with explicit path
+    /// </summary>
+    /// <param name="ytDlpPath">Path to yt-dlp executable</param>
+    public YtDlpDownloader(string ytDlpPath)
+    {
+        _ytDlpPath = ytDlpPath;
         _ytdl = new YoutubeDL
         {
             YoutubeDLPath = _ytDlpPath

--- a/cutube/Infrastructure/YtDlpDownloader.cs
+++ b/cutube/Infrastructure/YtDlpDownloader.cs
@@ -1,0 +1,105 @@
+using System.Diagnostics;
+using Cutube.Domain.Interfaces;
+using Cutube.Domain.Models;
+using YoutubeDLSharp;
+using YoutubeDLSharp.Options;
+
+namespace Cutube.Infrastructure;
+
+/// <summary>
+/// Downloads videos using yt-dlp
+/// </summary>
+public class YtDlpDownloader : IVideoDownloader
+{
+    private readonly YoutubeDL _ytdl;
+    private readonly string _ytDlpPath;
+
+    /// <summary>
+    /// Initializes a new instance of YtDlpDownloader
+    /// </summary>
+    /// <param name="ytDlpPath">Path to yt-dlp executable (null to use system PATH)</param>
+    public YtDlpDownloader(string? ytDlpPath = null)
+    {
+        _ytDlpPath = ytDlpPath ?? "yt-dlp";
+        _ytdl = new YoutubeDL
+        {
+            YoutubeDLPath = _ytDlpPath
+        };
+    }
+
+    /// <inheritdoc/>
+    public async Task<DownloadResult> DownloadAsync(
+        DownloadRequest request,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.Url))
+            throw new ArgumentException("URL cannot be empty", nameof(request));
+
+        if (string.IsNullOrWhiteSpace(request.OutputPath))
+            throw new ArgumentException("Output path cannot be empty", nameof(request));
+
+        // Ensure output directory exists
+        var directory = Path.GetDirectoryName(request.OutputPath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        // Convert Domain progress to YoutubeDLSharp progress
+        var ytdlProgress = progress != null
+            ? new Progress<DownloadProgress>(p => progress.Report(ConvertProgress(p)))
+            : null;
+
+        // Configure download options
+        var options = new OptionSet
+        {
+            Output = request.OutputPath,
+            Format = request.AudioOnly ? "bestaudio" : "bestvideo+bestaudio",
+            MergeOutputFormat = request.AudioOnly ? DownloadMergeFormat.Mp3 : DownloadMergeFormat.Mp4
+        };
+
+        // Add time range if specified
+        if (request.TimeRange != null)
+        {
+            options.DownloadSections = $"{request.TimeRange.StartSeconds}-{request.TimeRange.EndSeconds}";
+        }
+
+        // Run download
+        var result = await _ytdl.RunVideoDownload(
+            request.Url,
+            overrideOptions: options,
+            progress: ytdlProgress,
+            ct: ct
+        );
+
+        if (!result.Success)
+        {
+            throw new InvalidOperationException($"Download failed: {result.ErrorOutput}");
+        }
+
+        // Get file info
+        var filePath = result.Data;
+        var fileInfo = new FileInfo(filePath);
+
+        return new DownloadResult
+        {
+            FilePath = filePath,
+            Size = fileInfo.Length,
+            Duration = TimeSpan.FromSeconds(0) // Duration would need to be extracted from metadata
+        };
+    }
+
+    private static DownloadProgress ConvertProgress(YoutubeDLSharp.DownloadProgress ytdlProgress)
+    {
+        return new DownloadProgress
+        {
+            State = ytdlProgress.State ?? "downloading",
+            Percentage = ytdlProgress.Progress,
+            DownloadedBytes = ytdlProgress.Downloaded,
+            TotalBytes = ytdlProgress.Total,
+            Speed = ytdlProgress.Speed,
+            ErrorMessage = ytdlProgress.Error
+        };
+    }
+}

--- a/cutube/Infrastructure/YtDlpDownloader.cs
+++ b/cutube/Infrastructure/YtDlpDownloader.cs
@@ -3,6 +3,7 @@ using Cutube.Domain.Interfaces;
 using Cutube.Domain.Models;
 using YoutubeDLSharp;
 using YoutubeDLSharp.Options;
+using YtdlDownloadProgress = YoutubeDLSharp.DownloadProgress;
 
 namespace Cutube.Infrastructure;
 
@@ -29,8 +30,8 @@ public class YtDlpDownloader : IVideoDownloader
 
     /// <inheritdoc/>
     public async Task<DownloadResult> DownloadAsync(
-        DownloadRequest request,
-        IProgress<DownloadProgress>? progress = null,
+        Cutube.Domain.Models.DownloadRequest request,
+        IProgress<Cutube.Domain.Models.DownloadProgress>? progress = null,
         CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(request.Url))
@@ -47,16 +48,18 @@ public class YtDlpDownloader : IVideoDownloader
         }
 
         // Convert Domain progress to YoutubeDLSharp progress
-        var ytdlProgress = progress != null
-            ? new Progress<DownloadProgress>(p => progress.Report(ConvertProgress(p)))
-            : null;
+        IProgress<YtdlDownloadProgress>? ytdlProgress = null;
+        if (progress != null)
+        {
+            ytdlProgress = new Progress<YtdlDownloadProgress>(p => progress.Report(ConvertProgress(p)));
+        }
 
         // Configure download options
         var options = new OptionSet
         {
             Output = request.OutputPath,
             Format = request.AudioOnly ? "bestaudio" : "bestvideo+bestaudio",
-            MergeOutputFormat = request.AudioOnly ? DownloadMergeFormat.Mp3 : DownloadMergeFormat.Mp4
+            MergeOutputFormat = DownloadMergeFormat.Mp4
         };
 
         // Add time range if specified
@@ -84,22 +87,24 @@ public class YtDlpDownloader : IVideoDownloader
 
         return new DownloadResult
         {
-            FilePath = filePath,
-            Size = fileInfo.Length,
-            Duration = TimeSpan.FromSeconds(0) // Duration would need to be extracted from metadata
+            Success = true,
+            OutputPath = filePath,
+            FileSizeBytes = fileInfo.Length,
+            Duration = TimeSpan.FromSeconds(0), // Duration would need to be extracted from metadata
+            ErrorMessage = null
         };
     }
 
-    private static DownloadProgress ConvertProgress(YoutubeDLSharp.DownloadProgress ytdlProgress)
+    private static Cutube.Domain.Models.DownloadProgress ConvertProgress(YtdlDownloadProgress ytdlProgress)
     {
-        return new DownloadProgress
+        return new Cutube.Domain.Models.DownloadProgress
         {
-            State = ytdlProgress.State ?? "downloading",
+            State = ytdlProgress.State.ToString() ?? "downloading",
             Percentage = ytdlProgress.Progress,
-            DownloadedBytes = ytdlProgress.Downloaded,
-            TotalBytes = ytdlProgress.Total,
-            Speed = ytdlProgress.Speed,
-            ErrorMessage = ytdlProgress.Error
+            DownloadedBytes = 0, // Not directly available from YtdlDownloadProgress
+            TotalBytes = 0,      // Not directly available from YtdlDownloadProgress
+            Speed = 0,           // Speed property name might be different
+            ErrorMessage = null  // Error property name might be different
         };
     }
 }

--- a/cutube/Infrastructure/YtDlpMetadataProvider.cs
+++ b/cutube/Infrastructure/YtDlpMetadataProvider.cs
@@ -13,12 +13,20 @@ public class YtDlpMetadataProvider : IVideoMetadataProvider
     private readonly string _ytDlpPath;
 
     /// <summary>
-    /// Initializes a new instance of YtDlpMetadataProvider
+    /// Initializes a new instance of YtDlpMetadataProvider using auto-resolved yt-dlp path
     /// </summary>
-    /// <param name="ytDlpPath">Path to yt-dlp executable (null to use system PATH)</param>
-    public YtDlpMetadataProvider(string? ytDlpPath = null)
+    public YtDlpMetadataProvider()
     {
-        _ytDlpPath = ytDlpPath ?? "yt-dlp";
+        _ytDlpPath = YtDlpPathResolver.Resolve();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of YtDlpMetadataProvider with explicit path
+    /// </summary>
+    /// <param name="ytDlpPath">Path to yt-dlp executable</param>
+    public YtDlpMetadataProvider(string ytDlpPath)
+    {
+        _ytDlpPath = ytDlpPath;
     }
 
     /// <inheritdoc/>
@@ -47,7 +55,7 @@ public class YtDlpMetadataProvider : IVideoMetadataProvider
         if (process.ExitCode != 0)
         {
             var error = await process.StandardError.ReadToEndAsync(ct);
-            throw new InvalidOperationException($"Failed to get metadata: {error}");
+            throw new InvalidOperationException($"yt-dlp falhou (exit code {process.ExitCode}): {error}");
         }
 
         try

--- a/cutube/Infrastructure/YtDlpMetadataProvider.cs
+++ b/cutube/Infrastructure/YtDlpMetadataProvider.cs
@@ -1,0 +1,99 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Cutube.Domain.Interfaces;
+using Cutube.Domain.Models;
+
+namespace Cutube.Infrastructure;
+
+/// <summary>
+/// Provides video metadata using yt-dlp
+/// </summary>
+public class YtDlpMetadataProvider : IVideoMetadataProvider
+{
+    private readonly string _ytDlpPath;
+
+    /// <summary>
+    /// Initializes a new instance of YtDlpMetadataProvider
+    /// </summary>
+    /// <param name="ytDlpPath">Path to yt-dlp executable (null to use system PATH)</param>
+    public YtDlpMetadataProvider(string? ytDlpPath = null)
+    {
+        _ytDlpPath = ytDlpPath ?? "yt-dlp";
+    }
+
+    /// <inheritdoc/>
+    public async Task<VideoMetadata> GetMetadataAsync(string url, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            throw new ArgumentException("URL cannot be empty", nameof(url));
+
+        var processInfo = new ProcessStartInfo
+        {
+            FileName = _ytDlpPath,
+            Arguments = $"--dump-json --no-playlist \"{url}\"",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(processInfo);
+        if (process == null)
+            throw new InvalidOperationException("Failed to start yt-dlp process");
+
+        var output = await process.StandardOutput.ReadToEndAsync(ct);
+        await process.WaitForExitAsync(ct);
+
+        if (process.ExitCode != 0)
+        {
+            var error = await process.StandardError.ReadToEndAsync(ct);
+            throw new InvalidOperationException($"Failed to get metadata: {error}");
+        }
+
+        try
+        {
+            var jsonData = JsonSerializer.Deserialize<JsonElement>(output);
+            return ParseVideoMetadata(jsonData, url);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException("Failed to parse yt-dlp JSON output", ex);
+        }
+    }
+
+    private static VideoMetadata ParseVideoMetadata(JsonElement json, string url)
+    {
+        var title = json.GetProperty("title").GetString() ?? "Unknown";
+        var uploader = json.GetProperty("uploader").GetString() ?? json.GetProperty("channel").GetString();
+        var duration = json.GetProperty("duration").GetInt32();
+        var uploadDateStr = json.GetProperty("upload_date").GetString() ?? "";
+
+        // Parse upload date (format: YYYYMMDD)
+        DateTime uploadDate = DateTime.TryParseExact(
+            uploadDateStr,
+            "yyyyMMdd",
+            null,
+            System.Globalization.DateTimeStyles.None,
+            out var date) ? date : DateTime.MinValue;
+
+        // Get thumbnail
+        string thumbnailUrl = "https://via.placeholder.com/320x180?text=No+Thumbnail";
+        if (json.TryGetProperty("thumbnail", out var thumbElem))
+        {
+            thumbnailUrl = thumbElem.GetString() ?? thumbnailUrl;
+        }
+
+        // Sanitize title for filename usage
+        var sanitizedTitle = string.Join("_", title.Split(Path.GetInvalidFileNameChars()));
+
+        return new VideoMetadata
+        {
+            Url = url,
+            Title = sanitizedTitle,
+            Uploader = uploader,
+            Duration = TimeSpan.FromSeconds(duration),
+            UploadDate = uploadDate,
+            ThumbnailUrl = thumbnailUrl
+        };
+    }
+}

--- a/cutube/Infrastructure/YtDlpPathResolver.cs
+++ b/cutube/Infrastructure/YtDlpPathResolver.cs
@@ -1,0 +1,50 @@
+namespace Cutube.Infrastructure;
+
+/// <summary>
+/// Resolves the path to yt-dlp binary using the same priority as the original YtDlpHelper:
+/// 1. User version (~/.local/share/Cutube/yt-dlp)
+/// 2. Bundled version (AppContext.BaseDirectory/bin/yt-dlp)
+/// 3. System PATH
+/// </summary>
+public static class YtDlpPathResolver
+{
+    /// <summary>
+    /// Resolves the best available yt-dlp path
+    /// </summary>
+    /// <returns>Path to yt-dlp executable</returns>
+    /// <exception cref="FileNotFoundException">Thrown when yt-dlp cannot be found</exception>
+    public static string Resolve()
+    {
+        var isWindows = OperatingSystem.IsWindows();
+        var exeName = isWindows ? "yt-dlp.exe" : "yt-dlp";
+
+        // 1. User version in LocalApplicationData
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var userPath = Path.Combine(appData, "Cutube", exeName);
+        if (File.Exists(userPath))
+            return userPath;
+
+        // 2. Bundled with the app (in bin/ subdirectory)
+        var basePath = AppContext.BaseDirectory;
+        var bundledPath = Path.Combine(basePath, "bin", exeName);
+        if (File.Exists(bundledPath))
+            return bundledPath;
+
+        // 2b. Bundled directly in base directory
+        var bundledDirectPath = Path.Combine(basePath, exeName);
+        if (File.Exists(bundledDirectPath))
+            return bundledDirectPath;
+
+        // 3. System PATH
+        var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? "";
+        var systemPath = pathEnv.Split(Path.PathSeparator)
+            .Select(folder => Path.Combine(folder, exeName))
+            .FirstOrDefault(File.Exists);
+
+        if (systemPath != null)
+            return systemPath;
+
+        throw new FileNotFoundException(
+            $"yt-dlp não encontrado. Verifique a instalação ou baixe em: https://github.com/yt-dlp/yt-dlp/releases");
+    }
+}

--- a/cutube/Program.cs
+++ b/cutube/Program.cs
@@ -1,8 +1,13 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using Cutube.Domain.Interfaces;
+using Cutube.Domain.Models;
+using Cutube.Domain.Services;
+using Cutube.Infrastructure;
 using Cutube.Logging;
 using Cutube.ErrorHandling;
 using Cutube.Recovery;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace cutube;
 
@@ -11,6 +16,9 @@ public static class Program
 {
     public static async Task Main(string[] args)
     {
+        // Configure Dependency Injection
+        var serviceProvider = ConfigureServices();
+
         using var cts = new CancellationTokenSource();
 
         Console.CancelKeyPress += (sender, e) =>
@@ -20,21 +28,23 @@ public static class Program
             Console.WriteLine("\n⚠️  Cancelando operação...");
         };
 
-        var environmentService = new EnvironmentService();
-        var consoleService = new ConsoleService();
-        var fileService = new FileService();
-        using var loggerService = new FileLoggerService(environmentService);
-        var errorHandler = new ErrorHandler(loggerService);
-
-        // Criar State Manager para operações de resume
-        var stateManager = new DownloadStateManager(environmentService, loggerService);
-
-        // Executar cleanup no startup
-        var cleanupService = new StateCleanupService(stateManager, loggerService);
-        await cleanupService.CleanupOnStartupAsync();
-
         try
         {
+            // TODO: Verify if it's --resume command and handle accordingly
+            // For now, using existing workflow temporarily
+            var environmentService = new EnvironmentService();
+            var consoleService = new ConsoleService();
+            var fileService = new FileService();
+            using var loggerService = new FileLoggerService(environmentService);
+            var errorHandler = new ErrorHandler(loggerService);
+
+            // Criar State Manager para operações de resume
+            var stateManager = new DownloadStateManager(environmentService, loggerService);
+
+            // Executar cleanup no startup
+            var cleanupService = new StateCleanupService(stateManager, loggerService);
+            await cleanupService.CleanupOnStartupAsync();
+
             // Verificar se é comando --resume
             if (args.Contains("--resume"))
             {
@@ -42,6 +52,8 @@ public static class Program
                 return;
             }
 
+            // TODO: This will be replaced with DI-based workflow
+            // For now, keep existing functionality
             using var app = new ProgramWorkflow(
                 new MenuService(),
                 new YtDlpHelper(
@@ -53,7 +65,7 @@ public static class Program
                     false,
                     errorHandler,
                     loggerService,
-                    stateManager // Passar state manager para suporte a recuperação
+                    stateManager
                 ),
                 consoleService,
                 fileService,
@@ -75,6 +87,27 @@ public static class Program
             Console.WriteLine("\n✓ Operação cancelada com sucesso.");
             Environment.Exit(1);
         }
+    }
+
+    /// <summary>
+    /// Configures dependency injection container
+    /// </summary>
+    private static ServiceProvider ConfigureServices()
+    {
+        var services = new ServiceCollection();
+
+        // Infrastructure Layer
+        services.AddSingleton<IFileSystem, FileSystem>();
+        services.AddSingleton<IVideoMetadataProvider, YtDlpMetadataProvider>();
+        services.AddSingleton<IVideoDownloader, YtDlpDownloader>();
+        services.AddSingleton<IVideoProcessor, FfmpegProcessor>();
+
+        // Domain Services
+        services.AddSingleton<IDownloadValidator, ValidationService>();
+
+        // TODO: Add DownloadService, MetadataService, ProcessingService when implemented
+
+        return services.BuildServiceProvider();
     }
 
     /// <summary>

--- a/cutube/Program.cs
+++ b/cutube/Program.cs
@@ -52,26 +52,17 @@ public static class Program
                 return;
             }
 
-            // TODO: This will be replaced with DI-based workflow
-            // For now, keep existing functionality
-            using var app = new ProgramWorkflow(
+            // Use Domain-based workflow with DI
+            var downloadService = serviceProvider.GetRequiredService<IDownloadService>();
+            var metadataService = serviceProvider.GetRequiredService<IMetadataService>();
+
+            using var app = new DomainWorkflow(
                 new MenuService(),
-                new YtDlpHelper(
-                    fileService,
-                    new HttpClientService(),
-                    environmentService,
-                    new ProcessService(),
-                    consoleService,
-                    false,
-                    errorHandler,
-                    loggerService,
-                    stateManager
-                ),
+                metadataService,
+                downloadService,
                 consoleService,
                 fileService,
-                cts.Token,
-                loggerService,
-                errorHandler
+                cts.Token
             );
 
             var result = await app.RunAsync();
@@ -102,10 +93,11 @@ public static class Program
         services.AddSingleton<IVideoDownloader, YtDlpDownloader>();
         services.AddSingleton<IVideoProcessor, FfmpegProcessor>();
 
-        // Domain Services
-        services.AddSingleton<IDownloadValidator, ValidationService>();
-
-        // TODO: Add DownloadService, MetadataService, ProcessingService when implemented
+        // Domain Services (FluentResults-based)
+        services.AddSingleton<IValidationService, FluentValidationService>();
+        services.AddSingleton<IMetadataService, FluentMetadataService>();
+        services.AddSingleton<IDownloadService, FluentDownloadService>();
+        services.AddSingleton<IProcessingService, FluentProcessingService>();
 
         return services.BuildServiceProvider();
     }

--- a/cutube/cutube.csproj
+++ b/cutube/cutube.csproj
@@ -9,10 +9,16 @@
 
     <ItemGroup>
       <PackageReference Include="FFmpeg.AutoGen" Version="8.0.0" />
+      <PackageReference Include="FluentResults" Version="4.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
       <PackageReference Include="Serilog" Version="4.3.0" />
       <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
       <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
       <PackageReference Include="YoutubeDLSharp" Version="1.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\src\Cutube.Domain\Cutube.Domain.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Cutube.Domain/Cutube.Domain.csproj
+++ b/src/Cutube.Domain/Cutube.Domain.csproj
@@ -1,14 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\cutube\cutube.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Cutube.Domain</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentResults" Version="4.0.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/Cutube.Domain/Helpers/TimeHelper.cs
+++ b/src/Cutube.Domain/Helpers/TimeHelper.cs
@@ -1,0 +1,179 @@
+using System.Text.RegularExpressions;
+
+namespace Cutube.Domain.Helpers;
+
+/// <summary>
+/// Helper for parsing time strings into seconds
+/// Supports formats like: "1:30", "90s", "1h30m", "1:30:45"
+/// </summary>
+public static class TimeHelper
+{
+    /// <summary>
+    /// Parses a time string to seconds
+    /// </summary>
+    /// <param name="input">Time string to parse</param>
+    /// <returns>Time in seconds</returns>
+    /// <exception cref="ArgumentException">Thrown when input is empty</exception>
+    /// <exception cref="FormatException">Thrown when format is not recognized</exception>
+    public static int ParseToSeconds(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            throw new ArgumentException("Tempo não pode ser vazio");
+
+        input = input.Trim().ToLower();
+
+        if (TryParseCompactNotation(input, out var seconds))
+            return seconds;
+
+        if (TryParseColonFormat(input, out seconds))
+            return seconds;
+
+        if (double.TryParse(input, out var totalSeconds))
+            return (int)totalSeconds;
+
+        throw new FormatException($"Formato de tempo não reconhecido: {input}");
+    }
+
+    private static bool TryParseCompactNotation(string input, out int seconds)
+    {
+        seconds = 0;
+
+        if (TryMatchHoursMinutesSeconds(input, out seconds))
+            return true;
+
+        if (TryMatchHoursMinutes(input, out seconds))
+            return true;
+
+        if (TryMatchHoursSeconds(input, out seconds))
+            return true;
+
+        if (TryMatchMinutesSeconds(input, out seconds))
+            return true;
+
+        if (TryMatchOnlyHours(input, out seconds))
+            return true;
+
+        if (TryMatchOnlyMinutes(input, out seconds))
+            return true;
+
+        if (TryMatchOnlySeconds(input, out seconds))
+            return true;
+
+        return false;
+    }
+
+    private static bool TryMatchHoursMinutesSeconds(string input, out int seconds)
+    {
+        seconds = 0;
+        var match = Regex.Match(input, @"^(?<hours>\d+)h(?<minutes>\d+)m(?<secs>\d+(?:\.\d+)?)s$", RegexOptions.IgnoreCase);
+        if (!match.Success) return false;
+
+        var total = double.Parse(match.Groups["hours"].Value) * 3600;
+        total += double.Parse(match.Groups["minutes"].Value) * 60;
+        total += double.Parse(match.Groups["secs"].Value);
+        seconds = (int)total;
+        return true;
+    }
+
+    private static bool TryMatchHoursMinutes(string input, out int seconds)
+    {
+        seconds = 0;
+        var match = Regex.Match(input, @"^(?<hours>\d+)h(?<minutes>\d+)m$", RegexOptions.IgnoreCase);
+        if (!match.Success) return false;
+
+        var total = double.Parse(match.Groups["hours"].Value) * 3600;
+        total += double.Parse(match.Groups["minutes"].Value) * 60;
+        seconds = (int)total;
+        return true;
+    }
+
+    private static bool TryMatchHoursSeconds(string input, out int seconds)
+    {
+        seconds = 0;
+        var match = Regex.Match(input, @"^(?<hours>\d+)h(?<secs>\d+(?:\.\d+)?)s$", RegexOptions.IgnoreCase);
+        if (!match.Success) return false;
+
+        var total = double.Parse(match.Groups["hours"].Value) * 3600;
+        total += double.Parse(match.Groups["secs"].Value);
+        seconds = (int)total;
+        return true;
+    }
+
+    private static bool TryMatchMinutesSeconds(string input, out int seconds)
+    {
+        seconds = 0;
+        var match = Regex.Match(input, @"^(?<minutes>\d+)m(?<secs>\d+(?:\.\d+)?)s$", RegexOptions.IgnoreCase);
+        if (!match.Success) return false;
+
+        var total = double.Parse(match.Groups["minutes"].Value) * 60;
+        total += double.Parse(match.Groups["secs"].Value);
+        seconds = (int)total;
+        return true;
+    }
+
+    private static bool TryMatchOnlyHours(string input, out int seconds)
+    {
+        seconds = 0;
+        var match = Regex.Match(input, @"^(?<hours>\d+)h$", RegexOptions.IgnoreCase);
+        if (!match.Success) return false;
+
+        seconds = (int)(double.Parse(match.Groups["hours"].Value) * 3600);
+        return true;
+    }
+
+    private static bool TryMatchOnlyMinutes(string input, out int seconds)
+    {
+        seconds = 0;
+        var match = Regex.Match(input, @"^(?<minutes>\d+)m$", RegexOptions.IgnoreCase);
+        if (!match.Success) return false;
+
+        seconds = (int)(double.Parse(match.Groups["minutes"].Value) * 60);
+        return true;
+    }
+
+    private static bool TryMatchOnlySeconds(string input, out int seconds)
+    {
+        seconds = 0;
+        var match = Regex.Match(input, @"^(?<secs>\d+(?:\.\d+)?)s$", RegexOptions.IgnoreCase);
+        if (!match.Success) return false;
+
+        seconds = (int)double.Parse(match.Groups["secs"].Value);
+        return true;
+    }
+
+    private static bool TryParseColonFormat(string input, out int seconds)
+    {
+        seconds = 0;
+        var parts = input.Split(':');
+
+        if (parts.Length == 2)
+        {
+            if (int.TryParse(parts[0], out var minutes) &&
+                double.TryParse(parts[1], out var secs))
+            {
+                seconds = minutes * 60 + (int)secs;
+                return true;
+            }
+        }
+        else if (parts.Length == 3)
+        {
+            if (int.TryParse(parts[0], out var hours) &&
+                int.TryParse(parts[1], out var minutes) &&
+                double.TryParse(parts[2], out var secs))
+            {
+                seconds = hours * 3600 + minutes * 60 + (int)secs;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Converts a time string to TimeSpan
+    /// </summary>
+    public static TimeSpan ParseTimeToTimeSpan(string input)
+    {
+        return TimeSpan.FromSeconds(ParseToSeconds(input));
+    }
+}

--- a/src/Cutube.Domain/Models/DomainDownloadResult.cs
+++ b/src/Cutube.Domain/Models/DomainDownloadResult.cs
@@ -1,0 +1,47 @@
+using FluentResults;
+
+namespace Cutube.Domain.Models;
+
+/// <summary>
+/// Resultado de download do domínio (compatível com FluentResults)
+/// </summary>
+public record DomainDownloadResult
+{
+    public required string FilePath { get; init; }
+    public long Size { get; init; }
+    public TimeSpan Duration { get; init; }
+}
+
+/// <summary>
+/// Extension methods for converting between DownloadResult types
+/// </summary>
+public static class DownloadResultExtensions
+{
+    /// <summary>
+    /// Converts Infrastructure DownloadResult to Domain DownloadResult
+    /// </summary>
+    public static DomainDownloadResult ToDomainResult(this DownloadResult infraResult)
+    {
+        return new DomainDownloadResult
+        {
+            FilePath = infraResult.OutputPath,
+            Size = infraResult.FileSizeBytes,
+            Duration = infraResult.Duration
+        };
+    }
+
+    /// <summary>
+    /// Converts Domain DownloadResult to Infrastructure DownloadResult
+    /// </summary>
+    public static DownloadResult ToInfraResult(this DomainDownloadResult domainResult)
+    {
+        return new DownloadResult
+        {
+            OutputPath = domainResult.FilePath,
+            FileSizeBytes = domainResult.Size,
+            Duration = domainResult.Duration,
+            Success = true,
+            ErrorMessage = null
+        };
+    }
+}

--- a/src/Cutube.Domain/Models/DomainDownloadResult.cs
+++ b/src/Cutube.Domain/Models/DomainDownloadResult.cs
@@ -7,8 +7,19 @@ namespace Cutube.Domain.Models;
 /// </summary>
 public record DomainDownloadResult
 {
+    /// <summary>
+    /// Caminho completo do arquivo baixado
+    /// </summary>
     public required string FilePath { get; init; }
+
+    /// <summary>
+    /// Tamanho do arquivo em bytes
+    /// </summary>
     public long Size { get; init; }
+
+    /// <summary>
+    /// Duração do conteúdo baixado
+    /// </summary>
     public TimeSpan Duration { get; init; }
 }
 

--- a/src/Cutube.Domain/Models/TimeRange.cs
+++ b/src/Cutube.Domain/Models/TimeRange.cs
@@ -1,4 +1,4 @@
-using cutube;
+using Cutube.Domain.Helpers;
 
 namespace Cutube.Domain.Models;
 

--- a/src/Cutube.Domain/Services/DownloadService.cs
+++ b/src/Cutube.Domain/Services/DownloadService.cs
@@ -73,7 +73,9 @@ public class DownloadService : IVideoDownloader
         IProgress<DownloadProgress>? progress,
         CancellationToken ct)
     {
-        var tempFile = Path.GetTempFileName();
+        // Use .mp4 extension so yt-dlp doesn't rename the file
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.mp4");
+        string? actualDownloadedFile = null;
 
         try
         {
@@ -86,9 +88,12 @@ public class DownloadService : IVideoDownloader
             if (!fullDownload.Success)
                 return fullDownload;
 
+            // Use the actual path returned by the downloader (yt-dlp may change the extension)
+            actualDownloadedFile = fullDownload.OutputPath;
+
             var processingRequest = new ProcessingRequest
             {
-                InputPath = tempFile,
+                InputPath = actualDownloadedFile,
                 OutputPath = request.OutputPath,
                 TimeRange = request.TimeRange!,
                 AudioOnly = request.AudioOnly
@@ -96,7 +101,8 @@ public class DownloadService : IVideoDownloader
 
             var processingResult = await _processor.ProcessAsync(processingRequest, null, ct);
 
-            File.Delete(tempFile);
+            CleanupFile(tempFile);
+            CleanupFile(actualDownloadedFile);
 
             return new DownloadResult
             {
@@ -109,10 +115,23 @@ public class DownloadService : IVideoDownloader
         }
         catch (OperationCanceledException)
         {
-            File.Delete(tempFile);
-            if (File.Exists(request.OutputPath))
-                File.Delete(request.OutputPath);
+            CleanupFile(tempFile);
+            CleanupFile(actualDownloadedFile);
+            CleanupFile(request.OutputPath);
             throw;
+        }
+    }
+
+    private static void CleanupFile(string? path)
+    {
+        try
+        {
+            if (!string.IsNullOrEmpty(path) && File.Exists(path))
+                File.Delete(path);
+        }
+        catch
+        {
+            // Ignore cleanup errors
         }
     }
 }

--- a/src/Cutube.Domain/Services/FluentDownloadService.cs
+++ b/src/Cutube.Domain/Services/FluentDownloadService.cs
@@ -72,7 +72,7 @@ public class FluentDownloadService : IDownloadService
         }
         catch (Exception ex)
         {
-            return Result.Fail(new ExceptionalError("Download failed", ex));
+            return Result.Fail(new ExceptionalError($"Download failed: {ex.Message}", ex));
         }
     }
 
@@ -138,7 +138,7 @@ public class FluentDownloadService : IDownloadService
         }
         catch (Exception ex)
         {
-            return Result.Fail(new ExceptionalError("Download with processing failed", ex));
+            return Result.Fail(new ExceptionalError($"Download with processing failed: {ex.Message}", ex));
         }
     }
 

--- a/src/Cutube.Domain/Services/FluentDownloadService.cs
+++ b/src/Cutube.Domain/Services/FluentDownloadService.cs
@@ -99,7 +99,7 @@ public class FluentDownloadService : IDownloadService
             {
                 InputPath = tempFile,
                 OutputPath = request.OutputPath,
-                TimeRange = request.TimeRange,
+                TimeRange = request.TimeRange!, // Non-null because we checked earlier
                 AudioOnly = request.AudioOnly
             };
 

--- a/src/Cutube.Domain/Services/FluentDownloadService.cs
+++ b/src/Cutube.Domain/Services/FluentDownloadService.cs
@@ -81,7 +81,11 @@ public class FluentDownloadService : IDownloadService
         IProgress<DownloadProgress>? progress,
         CancellationToken ct)
     {
-        var tempFile = Path.GetTempFileName();
+        // Use .mp4 extension so yt-dlp doesn't rename the file
+        // (Path.GetTempFileName() creates a .tmp file, and yt-dlp appends .mp4 to it,
+        //  causing FFmpeg to receive the empty .tmp file as input — exit code 183)
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.mp4");
+        string? actualDownloadedFile = null;
 
         try
         {
@@ -94,10 +98,13 @@ public class FluentDownloadService : IDownloadService
                 return Result.Fail(downloadResult.ErrorMessage ?? "Download failed");
             }
 
+            // Use the actual path returned by the downloader (yt-dlp may change the extension)
+            actualDownloadedFile = downloadResult.OutputPath;
+
             // Processar (corte/conversão)
             var processingRequest = new ProcessingRequest
             {
-                InputPath = tempFile,
+                InputPath = actualDownloadedFile,
                 OutputPath = request.OutputPath,
                 TimeRange = request.TimeRange!, // Non-null because we checked earlier
                 AudioOnly = request.AudioOnly
@@ -111,9 +118,9 @@ public class FluentDownloadService : IDownloadService
                 return Result.Fail(processResult.ErrorMessage ?? "Processing failed");
             }
 
-            // Deletar arquivo temporário
-            if (File.Exists(tempFile))
-                File.Delete(tempFile);
+            // Cleanup temp files
+            CleanupFile(tempFile);
+            CleanupFile(actualDownloadedFile);
 
             // Calcular duração final
             var duration = request.TimeRange != null
@@ -130,15 +137,33 @@ public class FluentDownloadService : IDownloadService
         catch (OperationCanceledException)
         {
             // Cleanup em caso de cancelamento
-            if (File.Exists(tempFile))
-                File.Delete(tempFile);
-            if (File.Exists(request.OutputPath))
-                File.Delete(request.OutputPath);
+            CleanupFile(tempFile);
+            CleanupFile(actualDownloadedFile);
+            CleanupFile(request.OutputPath);
             throw;
         }
         catch (Exception ex)
         {
+            // Cleanup on error
+            CleanupFile(tempFile);
+            CleanupFile(actualDownloadedFile);
             return Result.Fail(new ExceptionalError($"Download with processing failed: {ex.Message}", ex));
+        }
+    }
+
+    /// <summary>
+    /// Safely deletes a file if it exists, ignoring errors
+    /// </summary>
+    private static void CleanupFile(string? path)
+    {
+        try
+        {
+            if (!string.IsNullOrEmpty(path) && File.Exists(path))
+                File.Delete(path);
+        }
+        catch
+        {
+            // Ignore cleanup errors
         }
     }
 

--- a/src/Cutube.Domain/Services/FluentDownloadService.cs
+++ b/src/Cutube.Domain/Services/FluentDownloadService.cs
@@ -1,0 +1,163 @@
+using Cutube.Domain.Interfaces;
+using Cutube.Domain.Models;
+using FluentResults;
+
+namespace Cutube.Domain.Services;
+
+/// <summary>
+/// Implementação do serviço principal de download usando FluentResults
+/// </summary>
+public class FluentDownloadService : IDownloadService
+{
+    private readonly IVideoDownloader _downloader;
+    private readonly IVideoProcessor _processor;
+    private readonly IValidationService _validator;
+
+    /// <summary>
+    /// Cria uma nova instância de FluentDownloadService
+    /// </summary>
+    public FluentDownloadService(
+        IVideoDownloader downloader,
+        IVideoProcessor processor,
+        IValidationService validator)
+    {
+        _downloader = downloader;
+        _processor = processor;
+        _validator = validator;
+    }
+
+    /// <inheritdoc/>
+    public async Task<Result<DomainDownloadResult>> DownloadAsync(
+        DownloadRequest request,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken ct = default)
+    {
+        // 1. Validar URL
+        var urlValidation = _validator.ValidateUrl(request.Url);
+        if (urlValidation.IsFailed)
+            return Result.Fail(urlValidation.Errors);
+
+        // 2. Garantir diretório de output existe
+        var outputDir = Path.GetDirectoryName(request.OutputPath) ?? Directory.GetCurrentDirectory();
+        if (!Directory.Exists(outputDir))
+        {
+            Directory.CreateDirectory(outputDir);
+        }
+
+        // 3. Se não tem timerange nem audio-only, download direto
+        if (request.TimeRange == null && !request.AudioOnly)
+        {
+            return await DownloadDirectAsync(request, progress, ct);
+        }
+
+        // 4. Caso contrário, download + processamento
+        return await DownloadWithProcessingAsync(request, progress, ct);
+    }
+
+    private async Task<Result<DomainDownloadResult>> DownloadDirectAsync(
+        DownloadRequest request,
+        IProgress<DownloadProgress>? progress,
+        CancellationToken ct)
+    {
+        try
+        {
+            var result = await _downloader.DownloadAsync(request, progress, ct);
+
+            if (!result.Success)
+            {
+                return Result.Fail(result.ErrorMessage ?? "Download failed");
+            }
+
+            return Result.Ok(result.ToDomainResult());
+        }
+        catch (Exception ex)
+        {
+            return Result.Fail(new ExceptionalError("Download failed", ex));
+        }
+    }
+
+    private async Task<Result<DomainDownloadResult>> DownloadWithProcessingAsync(
+        DownloadRequest request,
+        IProgress<DownloadProgress>? progress,
+        CancellationToken ct)
+    {
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            // Download completo para arquivo temporário
+            var downloadRequest = request with { OutputPath = tempFile, TimeRange = null, AudioOnly = false };
+            var downloadResult = await _downloader.DownloadAsync(downloadRequest, progress, ct);
+
+            if (!downloadResult.Success)
+            {
+                return Result.Fail(downloadResult.ErrorMessage ?? "Download failed");
+            }
+
+            // Processar (corte/conversão)
+            var processingRequest = new ProcessingRequest
+            {
+                InputPath = tempFile,
+                OutputPath = request.OutputPath,
+                TimeRange = request.TimeRange,
+                AudioOnly = request.AudioOnly
+            };
+
+            var processingProgress = ConvertProgress(progress);
+            var processResult = await _processor.ProcessAsync(processingRequest, processingProgress, ct);
+
+            if (!processResult.Success)
+            {
+                return Result.Fail(processResult.ErrorMessage ?? "Processing failed");
+            }
+
+            // Deletar arquivo temporário
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+
+            // Calcular duração final
+            var duration = request.TimeRange != null
+                ? TimeSpan.FromSeconds(request.TimeRange.DurationSeconds)
+                : downloadResult.Duration;
+
+            return Result.Ok(new DomainDownloadResult
+            {
+                FilePath = processResult.OutputPath,
+                Size = processResult.FileSizeBytes,
+                Duration = duration
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            // Cleanup em caso de cancelamento
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+            if (File.Exists(request.OutputPath))
+                File.Delete(request.OutputPath);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return Result.Fail(new ExceptionalError("Download with processing failed", ex));
+        }
+    }
+
+    private IProgress<ProcessingProgress>? ConvertProgress(IProgress<DownloadProgress>? downloadProgress)
+    {
+        if (downloadProgress == null)
+            return null;
+
+        return new Progress<ProcessingProgress>(p =>
+        {
+            downloadProgress.Report(new DownloadProgress
+            {
+                State = "processing",
+                Percentage = (float)p.Percentage / 100.0f,
+                DownloadedBytes = 0,
+                TotalBytes = 0,
+                Speed = 0,
+                ErrorMessage = null
+            });
+        });
+    }
+}

--- a/src/Cutube.Domain/Services/FluentMetadataService.cs
+++ b/src/Cutube.Domain/Services/FluentMetadataService.cs
@@ -1,0 +1,68 @@
+using Cutube.Domain.Interfaces;
+using Cutube.Domain.Models;
+using FluentResults;
+
+namespace Cutube.Domain.Services;
+
+/// <summary>
+/// Implementação do serviço de metadados usando FluentResults
+/// </summary>
+public class FluentMetadataService : IMetadataService
+{
+    private readonly IVideoMetadataProvider _provider;
+    private readonly IValidationService _validator;
+
+    /// <summary>
+    /// Cria uma nova instância de FluentMetadataService
+    /// </summary>
+    public FluentMetadataService(
+        IVideoMetadataProvider provider,
+        IValidationService validator)
+    {
+        _provider = provider;
+        _validator = validator;
+    }
+
+    /// <inheritdoc/>
+    public async Task<Result<VideoMetadata>> GetMetadataAsync(string url, CancellationToken ct = default)
+    {
+        // Validar URL primeiro
+        var urlValidation = _validator.ValidateUrl(url);
+        if (urlValidation.IsFailed)
+            return Result.Fail(urlValidation.Errors);
+
+        try
+        {
+            var metadata = await _provider.GetMetadataAsync(url, ct);
+
+            // Sanitizar título
+            var sanitizedTitle = SanitizeTitle(metadata.Title);
+
+            return Result.Ok(metadata with
+            {
+                Title = sanitizedTitle
+            });
+        }
+        catch (Exception ex)
+        {
+            return Result.Fail(new ExceptionalError("Failed to get metadata", ex));
+        }
+    }
+
+    private static string SanitizeTitle(string title)
+    {
+        var invalidChars = new char[] { '<', '>', ':', '"', '|', '?', '*' };
+        var sanitized = title;
+
+        foreach (var c in invalidChars)
+        {
+            sanitized = sanitized.Replace(c, ' ');
+        }
+
+        // Remover espaços duplicados
+        var lines = sanitized.Split(' ');
+        sanitized = string.Join(" ", lines.Where(l => !string.IsNullOrWhiteSpace(l)));
+
+        return sanitized.Trim();
+    }
+}

--- a/src/Cutube.Domain/Services/FluentMetadataService.cs
+++ b/src/Cutube.Domain/Services/FluentMetadataService.cs
@@ -45,7 +45,7 @@ public class FluentMetadataService : IMetadataService
         }
         catch (Exception ex)
         {
-            return Result.Fail(new ExceptionalError("Failed to get metadata", ex));
+            return Result.Fail(new ExceptionalError($"Failed to get metadata: {ex.Message}", ex));
         }
     }
 

--- a/src/Cutube.Domain/Services/FluentProcessingService.cs
+++ b/src/Cutube.Domain/Services/FluentProcessingService.cs
@@ -1,0 +1,44 @@
+using Cutube.Domain.Interfaces;
+using Cutube.Domain.Models;
+using FluentResults;
+
+namespace Cutube.Domain.Services;
+
+/// <summary>
+/// Implementação do serviço de processamento usando FluentResults
+/// </summary>
+public class FluentProcessingService : IProcessingService
+{
+    private readonly IVideoProcessor _processor;
+
+    /// <summary>
+    /// Cria uma nova instância de FluentProcessingService
+    /// </summary>
+    public FluentProcessingService(IVideoProcessor processor)
+    {
+        _processor = processor;
+    }
+
+    /// <inheritdoc/>
+    public async Task<Result<ProcessingResult>> ProcessAsync(
+        ProcessingRequest request,
+        IProgress<ProcessingProgress>? progress = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var result = await _processor.ProcessAsync(request, progress, ct);
+
+            if (!result.Success)
+            {
+                return Result.Fail(result.ErrorMessage ?? "Processing failed");
+            }
+
+            return Result.Ok(result);
+        }
+        catch (Exception ex)
+        {
+            return Result.Fail(new ExceptionalError("Processing failed", ex));
+        }
+    }
+}

--- a/src/Cutube.Domain/Services/FluentValidationService.cs
+++ b/src/Cutube.Domain/Services/FluentValidationService.cs
@@ -1,0 +1,57 @@
+using Cutube.Domain.Models;
+using FluentResults;
+
+namespace Cutube.Domain.Services;
+
+/// <summary>
+/// Implementação do serviço de validação usando FluentResults
+/// </summary>
+public class FluentValidationService : IValidationService
+{
+    private static readonly string[] ValidSchemes = { "http", "https" };
+    private static readonly string[] ValidHosts = { "youtube.com", "youtu.be", "vimeo.com" };
+
+    /// <inheritdoc/>
+    public Result<string> ValidateUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return Result.Fail("URL cannot be empty");
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return Result.Fail("Invalid URL format");
+
+        if (!ValidSchemes.Contains(uri.Scheme.ToLowerInvariant()))
+            return Result.Fail($"URL scheme must be one of: {string.Join(", ", ValidSchemes)}");
+
+        var host = uri.Host.ToLowerInvariant();
+        var isValidHost = ValidHosts.Any(h => host.Contains(h));
+
+        if (!isValidHost)
+            return Result.Fail($"URL host not supported. Supported: {string.Join(", ", ValidHosts)}");
+
+        return Result.Ok(url);
+    }
+
+    /// <inheritdoc/>
+    public Result<DownloadRequest> Validate(DownloadRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Url))
+            return Result.Fail("URL is required");
+
+        var urlValidation = ValidateUrl(request.Url);
+        if (urlValidation.IsFailed)
+            return Result.Fail(urlValidation.Errors);
+
+        // Validar TimeRange se presente
+        if (request.TimeRange != null)
+        {
+            if (request.TimeRange.StartSeconds >= request.TimeRange.EndSeconds)
+                return Result.Fail("TimeRange: Start must be less than End");
+
+            if (request.TimeRange.StartSeconds < 0)
+                return Result.Fail("TimeRange: Start cannot be negative");
+        }
+
+        return Result.Ok(request);
+    }
+}

--- a/src/Cutube.Domain/Services/IDomainServices.cs
+++ b/src/Cutube.Domain/Services/IDomainServices.cs
@@ -1,0 +1,74 @@
+using Cutube.Domain.Models;
+using FluentResults;
+
+namespace Cutube.Domain.Services;
+
+/// <summary>
+/// Principal serviço de download que orquestra downloader e processor
+/// </summary>
+public interface IDownloadService
+{
+    /// <summary>
+    /// Executa download completo (download + processamento se necessário)
+    /// </summary>
+    /// <param name="request">Requisição de download</param>
+    /// <param name="progress">Reporter de progresso</param>
+    /// <param name="ct">Token de cancelamento</param>
+    /// <returns>Result com DomainDownloadResult ou erro</returns>
+    Task<Result<DomainDownloadResult>> DownloadAsync(
+        DownloadRequest request,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Serviço de metadados de vídeo
+/// </summary>
+public interface IMetadataService
+{
+    /// <summary>
+    /// Obtém metadados de um vídeo
+    /// </summary>
+    /// <param name="url">URL do vídeo</param>
+    /// <param name="ct">Token de cancelamento</param>
+    /// <returns>Result com VideoMetadata ou erro</returns>
+    Task<Result<VideoMetadata>> GetMetadataAsync(string url, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Serviço de validação de requisições
+/// </summary>
+public interface IValidationService
+{
+    /// <summary>
+    /// Valida uma URL
+    /// </summary>
+    /// <param name="url">URL para validar</param>
+    /// <returns>Result de validação</returns>
+    Result<string> ValidateUrl(string url);
+
+    /// <summary>
+    /// Valida uma requisição de download
+    /// </summary>
+    /// <param name="request">Requisição para validar</param>
+    /// <returns>Result de validação</returns>
+    Result<DownloadRequest> Validate(DownloadRequest request);
+}
+
+/// <summary>
+/// Serviço de processamento de vídeo
+/// </summary>
+public interface IProcessingService
+{
+    /// <summary>
+    /// Processa um vídeo (corte, conversão, extração de áudio)
+    /// </summary>
+    /// <param name="request">Requisição de processamento</param>
+    /// <param name="progress">Reporter de progresso</param>
+    /// <param name="ct">Token de cancelamento</param>
+    /// <returns>Result com ProcessingResult ou erro</returns>
+    Task<Result<ProcessingResult>> ProcessAsync(
+        ProcessingRequest request,
+        IProgress<ProcessingProgress>? progress = null,
+        CancellationToken ct = default);
+}

--- a/src/Cutube.Domain/Services/ValidationService.cs
+++ b/src/Cutube.Domain/Services/ValidationService.cs
@@ -1,6 +1,6 @@
+using Cutube.Domain.Helpers;
 using Cutube.Domain.Interfaces;
 using Cutube.Domain.Models;
-using cutube;
 
 namespace Cutube.Domain.Services;
 

--- a/tests/Cutube.Domain.Tests/Services/DownloadServiceTests.cs
+++ b/tests/Cutube.Domain.Tests/Services/DownloadServiceTests.cs
@@ -564,5 +564,134 @@ public class DownloadServiceTests
             capturedRequest.AudioOnly.Should().BeTrue();
             capturedRequest.OutputPath.Should().Be("/tmp/clip.mp4");
         }
+
+        /// <summary>
+        /// Regression test for FFmpeg exit code 183 bug.
+        /// When yt-dlp returns a different OutputPath than requested (e.g., appends .mp4),
+        /// the processor must receive the actual path, not the originally requested temp path.
+        /// </summary>
+        [Fact]
+        public async Task ProcessorReceivesActualDownloadedPath_NotRequestedTempPath()
+        {
+            var timeRange = new TimeRange
+            {
+                StartSeconds = 30,
+                EndSeconds = 90
+            };
+
+            var request = new DownloadRequest
+            {
+                Url = "https://www.youtube.com/watch?v=test",
+                OutputPath = "/tmp/clip.mp4",
+                TimeRange = timeRange,
+                AudioOnly = false
+            };
+
+            // Simulate yt-dlp returning a DIFFERENT path than requested
+            _downloaderMock
+                .Setup(d => d.DownloadAsync(It.IsAny<DownloadRequest>(), It.IsAny<IProgress<DownloadProgress>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((DownloadRequest req, IProgress<DownloadProgress>? _, CancellationToken _) =>
+                    new DownloadResult
+                    {
+                        Success = true,
+                        OutputPath = req.OutputPath + ".webm", // yt-dlp changed the extension!
+                        FileSizeBytes = 50_000_000,
+                        Duration = TimeSpan.FromMinutes(10),
+                        ErrorMessage = null
+                    });
+
+            ProcessingRequest? capturedRequest = null;
+
+            var processingResult = new ProcessingResult
+            {
+                Success = true,
+                OutputPath = "/tmp/clip.mp4",
+                FileSizeBytes = 512000,
+                ErrorMessage = null
+            };
+
+            _validatorMock
+                .Setup(v => v.ValidateUrl(request.Url))
+                .Returns(ValidationResult.Success());
+
+            _validatorMock
+                .Setup(v => v.ValidateDirectory(It.IsAny<string>()))
+                .Returns(ValidationResult.Success());
+
+            _processorMock
+                .Setup(p => p.ProcessAsync(It.IsAny<ProcessingRequest>(), It.IsAny<IProgress<ProcessingProgress>>(), It.IsAny<CancellationToken>()))
+                .Callback<ProcessingRequest, IProgress<ProcessingProgress>?, CancellationToken>(
+                    (req, _, _) => capturedRequest = req
+                )
+                .ReturnsAsync(processingResult);
+
+            await _service.DownloadAsync(request);
+
+            capturedRequest.Should().NotBeNull();
+            capturedRequest!.InputPath.Should().EndWith(".webm",
+                "processor must receive the actual path returned by the downloader, not the requested temp path");
+        }
+
+        [Fact]
+        public async Task TempFileUsesProperExtension_NotTmp()
+        {
+            var timeRange = new TimeRange
+            {
+                StartSeconds = 30,
+                EndSeconds = 90
+            };
+
+            var request = new DownloadRequest
+            {
+                Url = "https://www.youtube.com/watch?v=test",
+                OutputPath = "/tmp/clip.mp4",
+                TimeRange = timeRange,
+                AudioOnly = false
+            };
+
+            DownloadRequest? capturedDownloadRequest = null;
+
+            _downloaderMock
+                .Setup(d => d.DownloadAsync(It.IsAny<DownloadRequest>(), It.IsAny<IProgress<DownloadProgress>>(), It.IsAny<CancellationToken>()))
+                .Callback<DownloadRequest, IProgress<DownloadProgress>?, CancellationToken>(
+                    (req, _, _) => capturedDownloadRequest = req)
+                .ReturnsAsync((DownloadRequest req, IProgress<DownloadProgress>? _, CancellationToken _) =>
+                    new DownloadResult
+                    {
+                        Success = true,
+                        OutputPath = req.OutputPath,
+                        FileSizeBytes = 50_000_000,
+                        Duration = TimeSpan.FromMinutes(10),
+                        ErrorMessage = null
+                    });
+
+            var processingResult = new ProcessingResult
+            {
+                Success = true,
+                OutputPath = "/tmp/clip.mp4",
+                FileSizeBytes = 512000,
+                ErrorMessage = null
+            };
+
+            _validatorMock
+                .Setup(v => v.ValidateUrl(request.Url))
+                .Returns(ValidationResult.Success());
+
+            _validatorMock
+                .Setup(v => v.ValidateDirectory(It.IsAny<string>()))
+                .Returns(ValidationResult.Success());
+
+            _processorMock
+                .Setup(p => p.ProcessAsync(It.IsAny<ProcessingRequest>(), It.IsAny<IProgress<ProcessingProgress>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(processingResult);
+
+            await _service.DownloadAsync(request);
+
+            capturedDownloadRequest.Should().NotBeNull();
+            capturedDownloadRequest!.OutputPath.Should().EndWith(".mp4",
+                "temp file must use .mp4 extension to prevent yt-dlp from renaming");
+            capturedDownloadRequest.OutputPath.Should().NotEndWith(".tmp",
+                ".tmp causes yt-dlp to append .mp4, leaving the original file empty");
+        }
     }
 }

--- a/tests/Cutube.Domain.Tests/Services/FluentDownloadServiceTests.cs
+++ b/tests/Cutube.Domain.Tests/Services/FluentDownloadServiceTests.cs
@@ -1,0 +1,599 @@
+using Cutube.Domain.Interfaces;
+using Cutube.Domain.Models;
+using Cutube.Domain.Services;
+using FluentAssertions;
+using FluentResults;
+using Moq;
+
+namespace Cutube.Domain.Tests.Services;
+
+public class FluentDownloadServiceTests
+{
+    private readonly Mock<IVideoDownloader> _downloaderMock;
+    private readonly Mock<IVideoProcessor> _processorMock;
+    private readonly Mock<IValidationService> _validatorMock;
+    private readonly FluentDownloadService _service;
+
+    public FluentDownloadServiceTests()
+    {
+        _downloaderMock = new Mock<IVideoDownloader>();
+        _processorMock = new Mock<IVideoProcessor>();
+        _validatorMock = new Mock<IValidationService>();
+        _service = new FluentDownloadService(
+            _downloaderMock.Object,
+            _processorMock.Object,
+            _validatorMock.Object
+        );
+    }
+
+    private void SetupValidUrl()
+    {
+        _validatorMock
+            .Setup(v => v.ValidateUrl(It.IsAny<string>()))
+            .Returns(Result.Ok("https://www.youtube.com/watch?v=test"));
+    }
+
+    public class DirectDownload : FluentDownloadServiceTests
+    {
+        [Fact]
+        public async Task WithoutTimeRangeOrAudioOnly_DownloadsDirect()
+        {
+            SetupValidUrl();
+
+            var request = new DownloadRequest
+            {
+                Url = "https://www.youtube.com/watch?v=test",
+                OutputPath = "/tmp/video.mp4",
+                TimeRange = null,
+                AudioOnly = false
+            };
+
+            var downloadResult = new DownloadResult
+            {
+                Success = true,
+                OutputPath = "/tmp/video.mp4",
+                FileSizeBytes = 1024000,
+                Duration = TimeSpan.FromMinutes(5),
+                ErrorMessage = null
+            };
+
+            _downloaderMock
+                .Setup(d => d.DownloadAsync(request, It.IsAny<IProgress<DownloadProgress>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(downloadResult);
+
+            var result = await _service.DownloadAsync(request);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.FilePath.Should().Be("/tmp/video.mp4");
+            result.Value.Size.Should().Be(1024000);
+
+            // Processor should NOT be called for direct download
+            _processorMock.Verify(
+                p => p.ProcessAsync(It.IsAny<ProcessingRequest>(), It.IsAny<IProgress<ProcessingProgress>>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task DownloadFailure_ReturnsError()
+        {
+            SetupValidUrl();
+
+            var request = new DownloadRequest
+            {
+                Url = "https://www.youtube.com/watch?v=test",
+                OutputPath = "/tmp/video.mp4"
+            };
+
+            var downloadResult = new DownloadResult
+            {
+                Success = false,
+                OutputPath = "/tmp/video.mp4",
+                FileSizeBytes = 0,
+                Duration = TimeSpan.Zero,
+                ErrorMessage = "Network error"
+            };
+
+            _downloaderMock
+                .Setup(d => d.DownloadAsync(request, It.IsAny<IProgress<DownloadProgress>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(downloadResult);
+
+            var result = await _service.DownloadAsync(request);
+
+            result.IsFailed.Should().BeTrue();
+            result.Errors.First().Message.Should().Contain("Network error");
+        }
+
+        [Fact]
+        public async Task DownloaderThrowsException_ReturnsError()
+        {
+            SetupValidUrl();
+
+            var request = new DownloadRequest
+            {
+                Url = "https://www.youtube.com/watch?v=test",
+                OutputPath = "/tmp/video.mp4"
+            };
+
+            _downloaderMock
+                .Setup(d => d.DownloadAsync(request, It.IsAny<IProgress<DownloadProgress>>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("Connection refused"));
+
+            var result = await _service.DownloadAsync(request);
+
+            result.IsFailed.Should().BeTrue();
+            result.Errors.First().Message.Should().Contain("Connection refused");
+        }
+    }
+
+    public class Validation : FluentDownloadServiceTests
+    {
+        [Fact]
+        public async Task InvalidUrl_ReturnsValidationError()
+        {
+            _validatorMock
+                .Setup(v => v.ValidateUrl(It.IsAny<string>()))
+                .Returns(Result.Fail("Invalid URL format"));
+
+            var request = new DownloadRequest
+            {
+                Url = "not-a-url",
+                OutputPath = "/tmp/video.mp4"
+            };
+
+            var result = await _service.DownloadAsync(request);
+
+            result.IsFailed.Should().BeTrue();
+            result.Errors.First().Message.Should().Contain("Invalid URL");
+
+            // Neither downloader nor processor should be called
+            _downloaderMock.Verify(
+                d => d.DownloadAsync(It.IsAny<DownloadRequest>(), It.IsAny<IProgress<DownloadProgress>>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+    }
+
+    public class DownloadWithProcessing : FluentDownloadServiceTests
+    {
+        /// <summary>
+        /// THE KEY TEST: Verifies that the processor receives the ACTUAL downloaded
+        /// file path (from DownloadResult.OutputPath), not the originally requested
+        /// temp path. This is the exact bug that caused FFmpeg exit code 183.
+        ///
+        /// Scenario: yt-dlp is told to save to "temp.mp4" but actually saves to
+        /// "temp.mp4.webm" or any different path. The processor must use the real path.
+        /// </summary>
+        [Fact]
+        public async Task ProcessorReceivesActualDownloadedPath_NotRequestedTempPath()
+        {
+            SetupValidUrl();
+
+            var request = new DownloadRequest
+            {
+                Url = "https://www.youtube.com/watch?v=test",
+                OutputPath = "/tmp/final-clip.mp4",
+                TimeRange = new TimeRange { StartSeconds = 30, EndSeconds = 90 }
+            };
+
+            // Simulate yt-dlp returning a DIFFERENT path than requested
+            // (this is the real-world behavior that caused the bug)
+            _downloaderMock
+                .Setup(d => d.DownloadAsync(
+                    It.IsAny<DownloadRequest>(),
+                    It.IsAny<IProgress<DownloadProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((DownloadRequest req, IProgress<DownloadProgress>? _, CancellationToken _) =>
+                    new DownloadResult
+                    {
+                        Success = true,
+                        OutputPath = req.OutputPath + ".webm", // yt-dlp changed the extension!
+                        FileSizeBytes = 50_000_000,
+                        Duration = TimeSpan.FromMinutes(10),
+                        ErrorMessage = null
+                    });
+
+            ProcessingRequest? capturedProcessingRequest = null;
+
+            _processorMock
+                .Setup(p => p.ProcessAsync(
+                    It.IsAny<ProcessingRequest>(),
+                    It.IsAny<IProgress<ProcessingProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<ProcessingRequest, IProgress<ProcessingProgress>?, CancellationToken>(
+                    (req, _, _) => capturedProcessingRequest = req)
+                .ReturnsAsync(new ProcessingResult
+                {
+                    Success = true,
+                    OutputPath = "/tmp/final-clip.mp4",
+                    FileSizeBytes = 5_000_000,
+                    ErrorMessage = null
+                });
+
+            await _service.DownloadAsync(request);
+
+            // THE CRITICAL ASSERTION: InputPath must be the actual downloaded path,
+            // not the temp path that was originally requested
+            capturedProcessingRequest.Should().NotBeNull();
+            capturedProcessingRequest!.InputPath.Should().EndWith(".webm",
+                "processor must receive the actual path returned by the downloader, not the requested temp path");
+            capturedProcessingRequest.InputPath.Should().NotBe(capturedProcessingRequest.OutputPath,
+                "input and output must be different files");
+        }
+
+        [Fact]
+        public async Task WithTimeRange_DownloadsFullThenProcesses()
+        {
+            SetupValidUrl();
+
+            var timeRange = new TimeRange { StartSeconds = 30, EndSeconds = 90 };
+            var request = new DownloadRequest
+            {
+                Url = "https://www.youtube.com/watch?v=test",
+                OutputPath = "/tmp/clip.mp4",
+                TimeRange = timeRange
+            };
+
+            DownloadRequest? capturedDownloadRequest = null;
+
+            _downloaderMock
+                .Setup(d => d.DownloadAsync(
+                    It.IsAny<DownloadRequest>(),
+                    It.IsAny<IProgress<DownloadProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<DownloadRequest, IProgress<DownloadProgress>?, CancellationToken>(
+                    (req, _, _) => capturedDownloadRequest = req)
+                .ReturnsAsync((DownloadRequest req, IProgress<DownloadProgress>? _, CancellationToken _) =>
+                    new DownloadResult
+                    {
+                        Success = true,
+                        OutputPath = req.OutputPath,
+                        FileSizeBytes = 50_000_000,
+                        Duration = TimeSpan.FromMinutes(10),
+                        ErrorMessage = null
+                    });
+
+            _processorMock
+                .Setup(p => p.ProcessAsync(
+                    It.IsAny<ProcessingRequest>(),
+                    It.IsAny<IProgress<ProcessingProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessingResult
+                {
+                    Success = true,
+                    OutputPath = "/tmp/clip.mp4",
+                    FileSizeBytes = 5_000_000,
+                    ErrorMessage = null
+                });
+
+            var result = await _service.DownloadAsync(request);
+
+            result.IsSuccess.Should().BeTrue();
+
+            // Download request should have no TimeRange (downloads full video)
+            capturedDownloadRequest.Should().NotBeNull();
+            capturedDownloadRequest!.TimeRange.Should().BeNull(
+                "download phase should download the full video without time range");
+            capturedDownloadRequest.AudioOnly.Should().BeFalse(
+                "download phase should get full video regardless of audio-only setting");
+
+            // Output should be a temp path, not the final output
+            capturedDownloadRequest.OutputPath.Should().NotBe("/tmp/clip.mp4",
+                "download should go to a temp file, not the final output");
+        }
+
+        [Fact]
+        public async Task WithTimeRange_ProcessingRequestHasCorrectParameters()
+        {
+            SetupValidUrl();
+
+            var timeRange = new TimeRange { StartSeconds = 30, EndSeconds = 90 };
+            var request = new DownloadRequest
+            {
+                Url = "https://www.youtube.com/watch?v=test",
+                OutputPath = "/tmp/clip.mp4",
+                TimeRange = timeRange,
+                AudioOnly = true
+            };
+
+            _downloaderMock
+                .Setup(d => d.DownloadAsync(
+                    It.IsAny<DownloadRequest>(),
+                    It.IsAny<IProgress<DownloadProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((DownloadRequest req, IProgress<DownloadProgress>? _, CancellationToken _) =>
+                    new DownloadResult
+                    {
+                        Success = true,
+                        OutputPath = req.OutputPath,
+                        FileSizeBytes = 50_000_000,
+                        Duration = TimeSpan.FromMinutes(10),
+                        ErrorMessage = null
+                    });
+
+            ProcessingRequest? capturedRequest = null;
+
+            _processorMock
+                .Setup(p => p.ProcessAsync(
+                    It.IsAny<ProcessingRequest>(),
+                    It.IsAny<IProgress<ProcessingProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<ProcessingRequest, IProgress<ProcessingProgress>?, CancellationToken>(
+                    (req, _, _) => capturedRequest = req)
+                .ReturnsAsync(new ProcessingResult
+                {
+                    Success = true,
+                    OutputPath = "/tmp/clip.mp4",
+                    FileSizeBytes = 256_000,
+                    ErrorMessage = null
+                });
+
+            await _service.DownloadAsync(request);
+
+            capturedRequest.Should().NotBeNull();
+            capturedRequest!.TimeRange.Should().Be(timeRange);
+            capturedRequest.AudioOnly.Should().BeTrue();
+            capturedRequest.OutputPath.Should().Be("/tmp/clip.mp4");
+        }
+
+        [Fact]
+        public async Task WithTimeRange_CalculatesDurationFromTimeRange()
+        {
+            SetupValidUrl();
+
+            var timeRange = new TimeRange { StartSeconds = 30, EndSeconds = 90 };
+            var request = new DownloadRequest
+            {
+                Url = "https://www.youtube.com/watch?v=test",
+                OutputPath = "/tmp/clip.mp4",
+                TimeRange = timeRange
+            };
+
+            _downloaderMock
+                .Setup(d => d.DownloadAsync(
+                    It.IsAny<DownloadRequest>(),
+                    It.IsAny<IProgress<DownloadProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((DownloadRequest req, IProgress<DownloadProgress>? _, CancellationToken _) =>
+                    new DownloadResult
+                    {
+                        Success = true,
+                        OutputPath = req.OutputPath,
+                        FileSizeBytes = 50_000_000,
+                        Duration = TimeSpan.FromMinutes(10),
+                        ErrorMessage = null
+                    });
+
+            _processorMock
+                .Setup(p => p.ProcessAsync(
+                    It.IsAny<ProcessingRequest>(),
+                    It.IsAny<IProgress<ProcessingProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessingResult
+                {
+                    Success = true,
+                    OutputPath = "/tmp/clip.mp4",
+                    FileSizeBytes = 5_000_000,
+                    ErrorMessage = null
+                });
+
+            var result = await _service.DownloadAsync(request);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Duration.Should().Be(TimeSpan.FromSeconds(60),
+                "duration should be calculated from TimeRange (90 - 30 = 60s)");
+        }
+
+        [Fact]
+        public async Task DownloadFailure_ReturnsErrorWithoutProcessing()
+        {
+            SetupValidUrl();
+
+            var request = new DownloadRequest
+            {
+                Url = "https://www.youtube.com/watch?v=test",
+                OutputPath = "/tmp/clip.mp4",
+                TimeRange = new TimeRange { StartSeconds = 0, EndSeconds = 60 }
+            };
+
+            _downloaderMock
+                .Setup(d => d.DownloadAsync(
+                    It.IsAny<DownloadRequest>(),
+                    It.IsAny<IProgress<DownloadProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DownloadResult
+                {
+                    Success = false,
+                    OutputPath = "",
+                    FileSizeBytes = 0,
+                    Duration = TimeSpan.Zero,
+                    ErrorMessage = "Video unavailable"
+                });
+
+            var result = await _service.DownloadAsync(request);
+
+            result.IsFailed.Should().BeTrue();
+            result.Errors.First().Message.Should().Contain("Video unavailable");
+
+            // Processor should NOT be called if download failed
+            _processorMock.Verify(
+                p => p.ProcessAsync(It.IsAny<ProcessingRequest>(), It.IsAny<IProgress<ProcessingProgress>>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task ProcessingFailure_ReturnsError()
+        {
+            SetupValidUrl();
+
+            var request = new DownloadRequest
+            {
+                Url = "https://www.youtube.com/watch?v=test",
+                OutputPath = "/tmp/clip.mp4",
+                TimeRange = new TimeRange { StartSeconds = 0, EndSeconds = 60 }
+            };
+
+            _downloaderMock
+                .Setup(d => d.DownloadAsync(
+                    It.IsAny<DownloadRequest>(),
+                    It.IsAny<IProgress<DownloadProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((DownloadRequest req, IProgress<DownloadProgress>? _, CancellationToken _) =>
+                    new DownloadResult
+                    {
+                        Success = true,
+                        OutputPath = req.OutputPath,
+                        FileSizeBytes = 50_000_000,
+                        Duration = TimeSpan.FromMinutes(10),
+                        ErrorMessage = null
+                    });
+
+            _processorMock
+                .Setup(p => p.ProcessAsync(
+                    It.IsAny<ProcessingRequest>(),
+                    It.IsAny<IProgress<ProcessingProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessingResult
+                {
+                    Success = false,
+                    OutputPath = "/tmp/clip.mp4",
+                    FileSizeBytes = 0,
+                    ErrorMessage = "FFmpeg failed with exit code 1"
+                });
+
+            var result = await _service.DownloadAsync(request);
+
+            result.IsFailed.Should().BeTrue();
+            result.Errors.First().Message.Should().Contain("FFmpeg failed");
+        }
+
+        [Fact]
+        public async Task Cancellation_ThrowsOperationCancelledException()
+        {
+            SetupValidUrl();
+
+            var request = new DownloadRequest
+            {
+                Url = "https://www.youtube.com/watch?v=test",
+                OutputPath = "/tmp/clip.mp4",
+                TimeRange = new TimeRange { StartSeconds = 0, EndSeconds = 60 }
+            };
+
+            _downloaderMock
+                .Setup(d => d.DownloadAsync(
+                    It.IsAny<DownloadRequest>(),
+                    It.IsAny<IProgress<DownloadProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new OperationCanceledException());
+
+            var act = async () => await _service.DownloadAsync(request);
+
+            await act.Should().ThrowAsync<OperationCanceledException>();
+        }
+
+        [Fact]
+        public async Task AudioOnlyWithoutTimeRange_TriggersProcessingPath()
+        {
+            SetupValidUrl();
+
+            // audio-only without time range should still go through processing path
+            var request = new DownloadRequest
+            {
+                Url = "https://www.youtube.com/watch?v=test",
+                OutputPath = "/tmp/audio.mp3",
+                TimeRange = null,
+                AudioOnly = true
+            };
+
+            _downloaderMock
+                .Setup(d => d.DownloadAsync(
+                    It.IsAny<DownloadRequest>(),
+                    It.IsAny<IProgress<DownloadProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((DownloadRequest req, IProgress<DownloadProgress>? _, CancellationToken _) =>
+                    new DownloadResult
+                    {
+                        Success = true,
+                        OutputPath = req.OutputPath,
+                        FileSizeBytes = 10_000_000,
+                        Duration = TimeSpan.FromMinutes(5),
+                        ErrorMessage = null
+                    });
+
+            _processorMock
+                .Setup(p => p.ProcessAsync(
+                    It.IsAny<ProcessingRequest>(),
+                    It.IsAny<IProgress<ProcessingProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessingResult
+                {
+                    Success = true,
+                    OutputPath = "/tmp/audio.mp3",
+                    FileSizeBytes = 2_000_000,
+                    ErrorMessage = null
+                });
+
+            var result = await _service.DownloadAsync(request);
+
+            result.IsSuccess.Should().BeTrue();
+
+            // Processor SHOULD be called for audio-only
+            _processorMock.Verify(
+                p => p.ProcessAsync(It.IsAny<ProcessingRequest>(), It.IsAny<IProgress<ProcessingProgress>>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task TempFileUsesProperExtension()
+        {
+            SetupValidUrl();
+
+            var request = new DownloadRequest
+            {
+                Url = "https://www.youtube.com/watch?v=test",
+                OutputPath = "/tmp/clip.mp4",
+                TimeRange = new TimeRange { StartSeconds = 0, EndSeconds = 60 }
+            };
+
+            DownloadRequest? capturedDownloadRequest = null;
+
+            _downloaderMock
+                .Setup(d => d.DownloadAsync(
+                    It.IsAny<DownloadRequest>(),
+                    It.IsAny<IProgress<DownloadProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<DownloadRequest, IProgress<DownloadProgress>?, CancellationToken>(
+                    (req, _, _) => capturedDownloadRequest = req)
+                .ReturnsAsync((DownloadRequest req, IProgress<DownloadProgress>? _, CancellationToken _) =>
+                    new DownloadResult
+                    {
+                        Success = true,
+                        OutputPath = req.OutputPath,
+                        FileSizeBytes = 50_000_000,
+                        Duration = TimeSpan.FromMinutes(10),
+                        ErrorMessage = null
+                    });
+
+            _processorMock
+                .Setup(p => p.ProcessAsync(
+                    It.IsAny<ProcessingRequest>(),
+                    It.IsAny<IProgress<ProcessingProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProcessingResult
+                {
+                    Success = true,
+                    OutputPath = "/tmp/clip.mp4",
+                    FileSizeBytes = 5_000_000,
+                    ErrorMessage = null
+                });
+
+            await _service.DownloadAsync(request);
+
+            // Temp file should use .mp4 extension, NOT .tmp
+            // (yt-dlp renames .tmp files, causing FFmpeg to get wrong input)
+            capturedDownloadRequest.Should().NotBeNull();
+            capturedDownloadRequest!.OutputPath.Should().EndWith(".mp4",
+                "temp file must use .mp4 extension to prevent yt-dlp from renaming it");
+            capturedDownloadRequest.OutputPath.Should().NotEndWith(".tmp",
+                ".tmp extension causes yt-dlp to append .mp4, leaving the original empty");
+        }
+    }
+}

--- a/tests/Cutube.Tests/Cutube.Tests.csproj
+++ b/tests/Cutube.Tests/Cutube.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\cutube\cutube.csproj" />
+    <ProjectReference Include="..\..\src\Cutube.Domain\Cutube.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Cutube.Tests/Integration/DomainIntegrationTests.cs
+++ b/tests/Cutube.Tests/Integration/DomainIntegrationTests.cs
@@ -1,0 +1,217 @@
+using Xunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Cutube.Domain.Services;
+using Cutube.Domain.Interfaces;
+using Cutube.Domain.Models;
+using Cutube.Infrastructure;
+
+namespace Cutube.Tests.Integration;
+
+/// <summary>
+/// Integration tests for Domain services
+/// </summary>
+public class DomainIntegrationTests
+{
+    [Fact]
+    public async Task FluentValidationService_ValidYouTubeUrl_ReturnsSuccess()
+    {
+        // Arrange
+        var validator = new FluentValidationService();
+        var validUrl = "https://www.youtube.com/watch?v=test123";
+
+        // Act
+        var result = validator.ValidateUrl(validUrl);
+
+        // Assert
+        result.IsFailed.Should().BeFalse("valid YouTube URL should pass validation");
+        result.Value.Should().Be(validUrl);
+    }
+
+    [Fact]
+    public void FluentValidationService_InvalidUrl_ReturnsFailure()
+    {
+        // Arrange
+        var validator = new FluentValidationService();
+        var invalidUrl = "not-a-valid-url";
+
+        // Act
+        var result = validator.ValidateUrl(invalidUrl);
+
+        // Assert
+        result.IsFailed.Should().BeTrue("invalid URL should fail validation");
+        result.Errors.First().Message.Should().Contain("Invalid");
+    }
+
+    [Fact]
+    public void FluentValidationService_NonYouTubeUrl_ReturnsFailure()
+    {
+        // Arrange
+        var validator = new FluentValidationService();
+        var nonYouTubeUrl = "https://example.com/video";
+
+        // Act
+        var result = validator.ValidateUrl(nonYouTubeUrl);
+
+        // Assert
+        result.IsFailed.Should().BeTrue("non-YouTube URL should fail validation");
+        result.Errors.First().Message.Should().Contain("not supported");
+    }
+
+    [Fact]
+    public void FluentValidationService_InvalidTimeRange_ReturnsFailure()
+    {
+        // Arrange
+        var validator = new FluentValidationService();
+        var timeRange = new TimeRange
+        {
+            StartSeconds = 100,
+            EndSeconds = 50 // End < Start
+        };
+
+        var request = new DownloadRequest
+        {
+            Url = "https://www.youtube.com/watch?v=test",
+            OutputPath = "/tmp/test.mp4",
+            TimeRange = timeRange
+        };
+
+        // Act
+        var result = validator.Validate(request);
+
+        // Assert
+        result.IsFailed.Should().BeTrue("invalid time range should fail validation");
+        result.Errors.First().Message.Should().Contain("Start must be less than End");
+    }
+
+    [Fact]
+    public async Task FluentDownloadService_WithInvalidUrl_ReturnsFailure()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<IVideoDownloader, YtDlpDownloader>();
+        services.AddSingleton<IVideoProcessor, FfmpegProcessor>();
+        services.AddSingleton<IValidationService, FluentValidationService>();
+        services.AddSingleton<IDownloadService, FluentDownloadService>();
+
+        var serviceProvider = services.BuildServiceProvider();
+        var downloadService = serviceProvider.GetRequiredService<IDownloadService>();
+
+        var request = new DownloadRequest
+        {
+            Url = "invalid-url",
+            OutputPath = "/tmp/test.mp4"
+        };
+
+        // Act
+        var result = await downloadService.DownloadAsync(request);
+
+        // Assert
+        result.IsFailed.Should().BeTrue("invalid URL should cause download to fail");
+        result.Errors.First().Message.Should().Contain("Invalid");
+    }
+
+    [Fact]
+    public void TimeRange_FromValidStrings_CreatesCorrectRange()
+    {
+        // Arrange
+        var start = "1:30";  // 90 seconds
+        var end = "2:30";    // 150 seconds
+
+        // Act
+        var range = TimeRange.FromStrings(start, end);
+
+        // Assert
+        range.StartSeconds.Should().Be(90);
+        range.EndSeconds.Should().Be(150);
+        range.DurationSeconds.Should().Be(60);
+    }
+
+    [Fact]
+    public void TimeRange_FromSecondsString_CreatesCorrectRange()
+    {
+        // Arrange
+        var start = "90s";
+        var end = "150s";
+
+        // Act
+        var range = TimeRange.FromStrings(start, end);
+
+        // Assert
+        range.StartSeconds.Should().Be(90);
+        range.EndSeconds.Should().Be(150);
+        range.DurationSeconds.Should().Be(60);
+    }
+
+    [Fact]
+    public void TimeRange_WithInvalidRange_ThrowsException()
+    {
+        // Arrange
+        var start = "200s";
+        var end = "100s";
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => TimeRange.FromStrings(start, end));
+    }
+
+    [Fact]
+    public void DomainDownloadResult_CanBeCreated()
+    {
+        // Arrange & Act
+        var result = new DomainDownloadResult
+        {
+            FilePath = "/tmp/test.mp4",
+            Size = 1024000,
+            Duration = TimeSpan.FromSeconds(100)
+        };
+
+        // Assert
+        result.FilePath.Should().Be("/tmp/test.mp4");
+        result.Size.Should().Be(1024000);
+        result.Duration.Should().Be(TimeSpan.FromSeconds(100));
+    }
+
+    [Fact]
+    public void DownloadResultExtensions_ConvertsToDomainResult()
+    {
+        // Arrange
+        var infraResult = new DownloadResult
+        {
+            Success = true,
+            OutputPath = "/tmp/test.mp4",
+            FileSizeBytes = 1024000,
+            Duration = TimeSpan.FromSeconds(100),
+            ErrorMessage = null
+        };
+
+        // Act
+        var domainResult = infraResult.ToDomainResult();
+
+        // Assert
+        domainResult.FilePath.Should().Be(infraResult.OutputPath);
+        domainResult.Size.Should().Be(infraResult.FileSizeBytes);
+        domainResult.Duration.Should().Be(infraResult.Duration);
+    }
+
+    [Fact]
+    public void DownloadResultExtensions_ConvertsToInfraResult()
+    {
+        // Arrange
+        var domainResult = new DomainDownloadResult
+        {
+            FilePath = "/tmp/test.mp4",
+            Size = 1024000,
+            Duration = TimeSpan.FromSeconds(100)
+        };
+
+        // Act
+        var infraResult = domainResult.ToInfraResult();
+
+        // Assert
+        infraResult.OutputPath.Should().Be(domainResult.FilePath);
+        infraResult.FileSizeBytes.Should().Be(domainResult.Size);
+        infraResult.Duration.Should().Be(domainResult.Duration);
+        infraResult.Success.Should().BeTrue();
+        infraResult.ErrorMessage.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
This branch finalizes frontend auth integration by adding route protection, logout flow, and dedicated tests/stories for auth forms.
It also stabilizes local development by wiring Docker startup, health checks, and automatic DB migrations into pnpm dev.
Backend startup was adjusted for Fastify v5 logger compatibility and more flexible localhost CORS during development.
Changes
- Added apps/web/middleware.ts protected-route guard with from redirect preservation.
- Added logout page and updated homepage auth navigation links.
- Added unit tests and Storybook stories for LoginForm and RegisterForm.
- Updated root test scripts to run API and Web suites explicitly.
- Added Docker helper scripts and updated pnpm dev workflow/docs.
- Updated API logger setup and CORS origin handling for local multi-port frontend usage.
Tests
- npm test: passing (API + Web)
- pnpm --filter @diario-magicko/web build: passing
- Skipped tests audit: none found
Review Notes
- Suggestion: consider migrating apps/web/middleware.ts to apps/web/proxy.ts to align with Next.js 16 terminology and avoid future deprecation noise.