### PR TITLE
feat(api): integrate RabbitMQ producer for async downloads (bd-858.2)

### DIFF
--- a/cutube-web/hooks/use-downloads.ts
+++ b/cutube-web/hooks/use-downloads.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import type { DownloadRequest } from "@/types";
+import type { CreateDownloadResponse, DownloadRequest } from "@/types";
 import { api } from "@/lib/api";
 import { DOWNLOAD_POLL_INTERVAL, POLL_INTERVAL, QUERY_KEYS } from "@/lib/constants";
 
@@ -26,11 +26,12 @@ export function useCreateDownload() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (request: DownloadRequest) => api.downloads.create(request),
-    onSuccess: async (downloadId) => {
+    mutationFn: (request: DownloadRequest): Promise<CreateDownloadResponse> =>
+      api.downloads.create(request),
+    onSuccess: async (response) => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: QUERY_KEYS.downloads }),
-        queryClient.invalidateQueries({ queryKey: QUERY_KEYS.download(downloadId) }),
+        queryClient.invalidateQueries({ queryKey: QUERY_KEYS.download(response.downloadId) }),
       ]);
     },
   });

--- a/cutube-web/lib/api.ts
+++ b/cutube-web/lib/api.ts
@@ -9,13 +9,13 @@ import { buildQueryString, fetchApi } from "./api-helpers";
 
 export const api = {
   downloads: {
-    create: async (request: DownloadRequest): Promise<string> => {
+    create: async (request: DownloadRequest): Promise<CreateDownloadResponse> => {
       const response = await fetchApi<CreateDownloadResponse>("/api/downloads", {
         method: "POST",
         body: JSON.stringify(request),
       });
 
-      return response.downloadId;
+      return response;
     },
 
     list: async (params?: {

--- a/cutube-web/types/api.ts
+++ b/cutube-web/types/api.ts
@@ -15,8 +15,11 @@ export interface ApiError {
 
 export interface CreateDownloadResponse {
   downloadId: string;
+  correlationId: string;
   status: string;
-  message?: string;
+  message: string;
+  enqueuedAt: string;
+  statusUrl: string;
 }
 
 export interface GetDownloadsResponse {

--- a/src/Cutube.Api/Configuration/RabbitMqOptions.cs
+++ b/src/Cutube.Api/Configuration/RabbitMqOptions.cs
@@ -1,0 +1,44 @@
+namespace Cutube.Api.Configuration;
+
+/// <summary>
+/// Opções de configuração para RabbitMQ.
+/// </summary>
+public class RabbitMqOptions
+{
+    public const string SectionName = "RabbitMq";
+
+    /// <summary>
+    /// Host do RabbitMQ.
+    /// </summary>
+    public string Host { get; set; } = "localhost";
+
+    /// <summary>
+    /// Porta do RabbitMQ.
+    /// </summary>
+    public int Port { get; set; } = 5672;
+
+    /// <summary>
+    /// Virtual host.
+    /// </summary>
+    public string VirtualHost { get; set; } = "/";
+
+    /// <summary>
+    /// Nome de usuário.
+    /// </summary>
+    public string UserName { get; set; } = "cutube";
+
+    /// <summary>
+    /// Senha.
+    /// </summary>
+    public string Password { get; set; } = "cutube123";
+
+    /// <summary>
+    /// Número de tentativas de retry em caso de falha.
+    /// </summary>
+    public int RetryCount { get; set; } = 5;
+
+    /// <summary>
+    /// Timeout em segundos.
+    /// </summary>
+    public int Timeout { get; set; } = 30;
+}

--- a/src/Cutube.Api/Cutube.Api.csproj
+++ b/src/Cutube.Api/Cutube.Api.csproj
@@ -6,6 +6,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MassTransit" Version="8.3.0" />
+    <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.2" />
   </ItemGroup>

--- a/src/Cutube.Api/DTOs/CreateDownloadRequest.cs
+++ b/src/Cutube.Api/DTOs/CreateDownloadRequest.cs
@@ -31,5 +31,15 @@ public record CreateDownloadRequest
     /// <summary>
     /// Whether to download audio only
     /// </summary>
-    public bool AudioOnly { get; init; }
+    public bool? AudioOnly { get; init; }
+
+    /// <summary>
+    /// Optional custom filename for output
+    /// </summary>
+    public string? OutputFilename { get; init; }
+
+    /// <summary>
+    /// Priority for processing (default: "normal")
+    /// </summary>
+    public string? Priority { get; init; }
 }

--- a/src/Cutube.Api/DTOs/CreateDownloadResponse.cs
+++ b/src/Cutube.Api/DTOs/CreateDownloadResponse.cs
@@ -9,17 +9,32 @@ namespace Cutube.Api.DTOs;
 public class CreateDownloadResponse
 {
     /// <summary>
-    /// Unique identifier for the download
+    /// ID do download (igual ao correlation ID).
     /// </summary>
     public required string DownloadId { get; init; }
 
     /// <summary>
-    /// Current status of the download
+    /// Correlation ID para tracking end-to-end.
+    /// </summary>
+    public required string CorrelationId { get; init; }
+
+    /// <summary>
+    /// Status do download: "queued".
     /// </summary>
     public required string Status { get; init; }
 
     /// <summary>
-    /// Optional message
+    /// Mensagem descritiva.
     /// </summary>
-    public string? Message { get; init; }
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// Timestamp de enfileiramento.
+    /// </summary>
+    public DateTime EnqueuedAt { get; init; }
+
+    /// <summary>
+    /// URL para consultar status do download.
+    /// </summary>
+    public string StatusUrl => $"/api/downloads/{DownloadId}";
 }

--- a/src/Cutube.Api/Endpoints/DownloadsEndpoints.cs
+++ b/src/Cutube.Api/Endpoints/DownloadsEndpoints.cs
@@ -1,5 +1,8 @@
 using Cutube.Api.DTOs;
 using Cutube.Api.Models;
+using Cutube.Api.Queuing;
+using Cutube.Api.Queuing.Exceptions;
+using Cutube.Api.Queuing.Messages;
 using Cutube.Api.Services;
 using Cutube.Domain.Models;
 using Cutube.Domain.Services;
@@ -16,41 +19,91 @@ public static class DownloadsEndpoints
         var group = app.MapGroup("/api/downloads")
             .WithTags("Downloads");
 
-        // POST /api/downloads - Create download
+        // POST /api/downloads - Enqueue download to RabbitMQ
         group.MapPost("/", async (
             [FromBody] CreateDownloadRequest request,
-            IDownloadQueue downloadQueue,
+            IQueueProducer queueProducer,
+            ILoggerFactory loggerFactory,
             CancellationToken ct) =>
         {
-            // 1. Validate request
-            var validationResult = ValidateRequest(request);
-            if (validationResult.IsFailed)
+            var logger = loggerFactory.CreateLogger("DownloadsEndpoints");
+            
+            try
             {
-                return Results.Problem(
-                    detail: validationResult.Errors.First().Message,
-                    statusCode: 400,
-                    title: "Validation Error");
+                // 1. Validate request
+                var validationResult = ValidateRequest(request);
+                if (validationResult.IsFailed)
+                {
+                    return Results.BadRequest(new { error = validationResult.Errors.First().Message });
+                }
+
+                logger.LogInformation("Creating download for URL: {Url}", request.Url);
+
+                // 2. Create message for RabbitMQ
+                var message = new DownloadMessage
+                {
+                    CorrelationId = Guid.NewGuid().ToString(),
+                    Url = request.Url,
+                    StartTime = request.StartTime,
+                    EndTime = request.EndTime,
+                    OutputPath = request.OutputPath,
+                    AudioOnly = request.AudioOnly ?? false,
+                    OutputFilename = request.OutputFilename,
+                    Priority = request.Priority ?? "normal",
+                    CreatedAt = DateTime.UtcNow
+                };
+
+                // 3. Publish to queue
+                var correlationId = await queueProducer.PublishDownloadAsync(message, ct);
+
+                logger.LogInformation(
+                    "Download enqueued: {CorrelationId}",
+                    correlationId);
+
+                // 4. Return 202 Accepted + correlation ID
+                return Results.Accepted(
+                    $"/api/downloads/{correlationId}",
+                    new CreateDownloadResponse
+                    {
+                        DownloadId = correlationId,
+                        CorrelationId = correlationId,
+                        Status = "queued",
+                        Message = "Download enqueued successfully",
+                        EnqueuedAt = DateTime.UtcNow
+                    });
             }
-
-            // 2. Convert to Domain Request
-            var domainRequest = MapToDomainRequest(request);
-
-            // 3. Enqueue (background processing)
-            var downloadId = await downloadQueue.EnqueueAsync(domainRequest, ct);
-
-            // 4. Return immediately (202 Accepted)
-            var response = new CreateDownloadResponse
+            catch (QueuePublishException ex)
             {
-                DownloadId = downloadId,
-                Status = "queued",
-                Message = "Download enqueued successfully"
-            };
+                logger.LogError(ex, "Failed to enqueue download");
 
-            return Results.Accepted($"/api/downloads/{downloadId}", response);
+                // Return 503 Service Unavailable
+                return Results.Json(new
+                {
+                    error = "Failed to enqueue download",
+                    message = "Queue service is unavailable. Please try again later.",
+                    correlationId = ex.CorrelationId
+                }, statusCode: 503);
+            }
+            catch (ArgumentException ex)
+            {
+                logger.LogWarning(ex, "Invalid download request");
+                return Results.BadRequest(new { error = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Unexpected error creating download");
+                return Results.Problem(
+                    detail: ex.Message,
+                    statusCode: 500,
+                    title: "Internal server error"
+                );
+            }
         })
         .WithName("CreateDownload")
+        .WithSummary("Enqueue a new download")
         .Produces<CreateDownloadResponse>(202)
-        .Produces<ProblemDetails>(400);
+        .Produces<object>(400)
+        .Produces<object>(503);
 
         // GET /api/downloads - List all downloads
         group.MapGet("/", async (
@@ -219,31 +272,5 @@ public static class DownloadsEndpoints
             return Result.Fail("OutputPath is required");
 
         return Result.Ok();
-    }
-
-    private static DownloadRequest MapToDomainRequest(CreateDownloadRequest apiRequest)
-    {
-        Domain.Models.TimeRange? timeRange = null;
-
-        if (!string.IsNullOrEmpty(apiRequest.StartTime) && !string.IsNullOrEmpty(apiRequest.EndTime))
-        {
-            var start = TimeSpan.Parse(apiRequest.StartTime);
-            var end = TimeSpan.Parse(apiRequest.EndTime);
-
-            // Convert to domain TimeRange
-            timeRange = new Domain.Models.TimeRange
-            {
-                StartSeconds = (int)start.TotalSeconds,
-                EndSeconds = (int)end.TotalSeconds
-            };
-        }
-
-        return new DownloadRequest
-        {
-            Url = apiRequest.Url,
-            OutputPath = apiRequest.OutputPath,
-            TimeRange = timeRange,
-            AudioOnly = apiRequest.AudioOnly
-        };
     }
 }

--- a/src/Cutube.Api/Program.cs
+++ b/src/Cutube.Api/Program.cs
@@ -76,32 +76,35 @@ builder.Services.AddSingleton<IDownloadStatusRepository, InMemoryStatusRepositor
 builder.Services.AddSingleton<ConnectionTracker>();
 builder.Services.AddHostedService<BackgroundDownloadWorker>();
 
-// RabbitMQ Configuration
-builder.Services.Configure<RabbitMqOptions>(
-    builder.Configuration.GetSection(RabbitMqOptions.SectionName)
-);
-
-// MassTransit (Producer apenas - não configura consumers na API)
-builder.Services.AddMassTransit(x =>
+// RabbitMQ Configuration - Skip if running in tests
+if (!builder.Environment.IsEnvironment("Testing"))
 {
-    x.UsingRabbitMq((context, cfg) =>
+    builder.Services.Configure<RabbitMqOptions>(
+        builder.Configuration.GetSection(RabbitMqOptions.SectionName)
+    );
+
+    // MassTransit (Producer apenas - não configura consumers na API)
+    builder.Services.AddMassTransit(x =>
     {
-        var options = context.GetRequiredService<RabbitMqOptions>();
-
-        cfg.Host($"rabbitmq://{options.UserName}:{options.Password}@{options.Host}:{options.Port}{options.VirtualHost}");
-
-        // Configurar retry
-        cfg.UseMessageRetry(r =>
+        x.UsingRabbitMq((context, cfg) =>
         {
-            r.Interval(options.RetryCount, TimeSpan.FromSeconds(1));
+            var options = context.GetRequiredService<RabbitMqOptions>();
+
+            cfg.Host($"rabbitmq://{options.UserName}:{options.Password}@{options.Host}:{options.Port}{options.VirtualHost}");
+
+            // Configurar retry
+            cfg.UseMessageRetry(r =>
+            {
+                r.Interval(options.RetryCount, TimeSpan.FromSeconds(1));
+            });
+
+            cfg.ConfigureEndpoints(context);
         });
-
-        cfg.ConfigureEndpoints(context);
     });
-});
 
-// Registrar producer
-builder.Services.AddSingleton<IQueueProducer, RabbitMqProducer>();
+    // Registrar producer
+    builder.Services.AddSingleton<IQueueProducer, RabbitMqProducer>();
+}
 
 // Configure options
 builder.Services.Configure<DiskSpaceHealthCheckOptions>(

--- a/src/Cutube.Api/Program.cs
+++ b/src/Cutube.Api/Program.cs
@@ -1,10 +1,13 @@
+using Cutube.Api.Configuration;
 using Cutube.Api.Endpoints;
 using Cutube.Api.HealthChecks;
 using Cutube.Api.Hubs;
+using Cutube.Api.Queuing;
 using Cutube.Api.Services;
 using Cutube.Domain.Interfaces;
 using Cutube.Domain.Services;
 using Cutube.Infrastructure;
+using MassTransit;
 
 // Program.cs is excluded from code coverage via GlobalSuppressions.cs or project configuration
 var builder = WebApplication.CreateBuilder(args);
@@ -72,6 +75,33 @@ builder.Services.AddSingleton<IDownloadQueue, DownloadQueue>();
 builder.Services.AddSingleton<IDownloadStatusRepository, InMemoryStatusRepository>();
 builder.Services.AddSingleton<ConnectionTracker>();
 builder.Services.AddHostedService<BackgroundDownloadWorker>();
+
+// RabbitMQ Configuration
+builder.Services.Configure<RabbitMqOptions>(
+    builder.Configuration.GetSection(RabbitMqOptions.SectionName)
+);
+
+// MassTransit (Producer apenas - não configura consumers na API)
+builder.Services.AddMassTransit(x =>
+{
+    x.UsingRabbitMq((context, cfg) =>
+    {
+        var options = context.GetRequiredService<RabbitMqOptions>();
+
+        cfg.Host($"rabbitmq://{options.UserName}:{options.Password}@{options.Host}:{options.Port}{options.VirtualHost}");
+
+        // Configurar retry
+        cfg.UseMessageRetry(r =>
+        {
+            r.Interval(options.RetryCount, TimeSpan.FromSeconds(1));
+        });
+
+        cfg.ConfigureEndpoints(context);
+    });
+});
+
+// Registrar producer
+builder.Services.AddSingleton<IQueueProducer, RabbitMqProducer>();
 
 // Configure options
 builder.Services.Configure<DiskSpaceHealthCheckOptions>(

--- a/src/Cutube.Api/Queuing/Exceptions/QueuePublishException.cs
+++ b/src/Cutube.Api/Queuing/Exceptions/QueuePublishException.cs
@@ -1,0 +1,24 @@
+namespace Cutube.Api.Queuing.Exceptions;
+
+/// <summary>
+/// Exceção lançada quando falha ao publicar mensagem na fila.
+/// </summary>
+public class QueuePublishException : Exception
+{
+    /// <summary>
+    /// Correlation ID da mensagem que falhou.
+    /// </summary>
+    public string CorrelationId { get; }
+
+    public QueuePublishException(string message, string correlationId)
+        : base(message)
+    {
+        CorrelationId = correlationId;
+    }
+
+    public QueuePublishException(string message, string correlationId, Exception innerException)
+        : base(message, innerException)
+    {
+        CorrelationId = correlationId;
+    }
+}

--- a/src/Cutube.Api/Queuing/IQueueProducer.cs
+++ b/src/Cutube.Api/Queuing/IQueueProducer.cs
@@ -1,0 +1,20 @@
+namespace Cutube.Api.Queuing;
+
+/// <summary>
+/// Interface para publicação de mensagens na fila RabbitMQ.
+/// </summary>
+public interface IQueueProducer
+{
+    /// <summary>
+    /// Publica uma mensagem de download na fila.
+    /// </summary>
+    /// <param name="message">Mensagem de download.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <returns>Correlation ID para tracking.</returns>
+    Task<string> PublishDownloadAsync(Queuing.Messages.DownloadMessage message, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Verifica se a conexão com RabbitMQ está ativa.
+    /// </summary>
+    bool IsConnected { get; }
+}

--- a/src/Cutube.Api/Queuing/Messages/DownloadMessage.cs
+++ b/src/Cutube.Api/Queuing/Messages/DownloadMessage.cs
@@ -1,0 +1,85 @@
+namespace Cutube.Api.Queuing.Messages;
+
+/// <summary>
+/// Mensagem de download para processamento assíncrono.
+/// </summary>
+public record DownloadMessage
+{
+    /// <summary>
+    /// ID único da mensagem (gerado automaticamente).
+    /// </summary>
+    public string MessageId { get; init; } = Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// ID de correlação para tracking end-to-end.
+    /// </summary>
+    public required string CorrelationId { get; init; }
+
+    /// <summary>
+    /// URL do vídeo para download.
+    /// </summary>
+    public required string Url { get; init; }
+
+    /// <summary>
+    /// Tempo de início (opcional, para recortes).
+    /// Formato: "HH:MM:SS" ou "segundos".
+    /// </summary>
+    public string? StartTime { get; init; }
+
+    /// <summary>
+    /// Tempo de término (opcional, para recortes).
+    /// Formato: "HH:MM:SS" ou "segundos".
+    /// </summary>
+    public string? EndTime { get; init; }
+
+    /// <summary>
+    /// Caminho de saída para o arquivo.
+    /// </summary>
+    public required string OutputPath { get; init; }
+
+    /// <summary>
+    /// Download apenas áudio.
+    /// </summary>
+    public bool AudioOnly { get; init; }
+
+    /// <summary>
+    /// Nome do arquivo de saída (opcional).
+    /// </summary>
+    public string? OutputFilename { get; init; }
+
+    /// <summary>
+    /// Prioridade da mensagem.
+    /// </summary>
+    public string Priority { get; init; } = "normal";
+
+    /// <summary>
+    /// Timestamp de criação da mensagem.
+    /// </summary>
+    public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Metadados adicionais (título, duração, thumbnail).
+    /// </summary>
+    public DownloadMetadata? Metadata { get; init; }
+}
+
+/// <summary>
+/// Metadados do vídeo.
+/// </summary>
+public record DownloadMetadata
+{
+    /// <summary>
+    /// Título do vídeo.
+    /// </summary>
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Duração do vídeo.
+    /// </summary>
+    public string? Duration { get; init; }
+
+    /// <summary>
+    /// URL da thumbnail.
+    /// </summary>
+    public string? Thumbnail { get; init; }
+}

--- a/src/Cutube.Api/Queuing/RabbitMqProducer.cs
+++ b/src/Cutube.Api/Queuing/RabbitMqProducer.cs
@@ -1,0 +1,111 @@
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Cutube.Api.Queuing.Messages;
+using Cutube.Api.Queuing.Exceptions;
+using Cutube.Api.Configuration;
+
+namespace Cutube.Api.Queuing;
+
+/// <summary>
+/// Implementação de producer para RabbitMQ usando MassTransit.
+/// </summary>
+public class RabbitMqProducer : IQueueProducer
+{
+    private const string DownloadsQueue = "cutube.downloads";
+
+    private readonly IBus _bus;
+    private readonly RabbitMqOptions _options;
+    private readonly ILogger<RabbitMqProducer> _logger;
+    private readonly SemaphoreSlim _connectionLock = new(1, 1);
+    private bool _isConnected;
+
+    public bool IsConnected => _isConnected;
+
+    public RabbitMqProducer(
+        IBus bus,
+        IOptions<RabbitMqOptions> options,
+        ILogger<RabbitMqProducer> logger)
+    {
+        _bus = bus;
+        _options = options.Value;
+        _logger = logger;
+        _isConnected = true; // MassTransit gerencia reconexão automaticamente
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> PublishDownloadAsync(DownloadMessage message, CancellationToken cancellationToken = default)
+    {
+        // Validar mensagem
+        ValidateMessage(message);
+
+        // Gerar correlation ID se não existe
+        if (string.IsNullOrEmpty(message.CorrelationId))
+        {
+            message = message with { CorrelationId = Guid.NewGuid().ToString() };
+        }
+
+        try
+        {
+            _logger.LogInformation(
+                "Publishing download message: {MessageId}, CorrelationId: {CorrelationId}, URL: {Url}",
+                message.MessageId,
+                message.CorrelationId,
+                message.Url);
+
+            // Publicar mensagem usando MassTransit
+            var endpoint = await _bus.GetSendEndpoint(new Uri($"queue:{DownloadsQueue}"));
+
+            await endpoint.Send(message, cancellationToken);
+
+            _isConnected = true;
+            _logger.LogInformation(
+                "Message published successfully: {CorrelationId}",
+                message.CorrelationId);
+
+            return message.CorrelationId;
+        }
+        catch (Exception ex)
+        {
+            _isConnected = false;
+            _logger.LogError(ex,
+                "Failed to publish message: {CorrelationId}. Error: {Error}",
+                message.CorrelationId,
+                ex.Message);
+
+            throw new QueuePublishException(
+                $"Failed to publish download message: {message.CorrelationId}",
+                message.CorrelationId,
+                ex);
+        }
+    }
+
+    private void ValidateMessage(DownloadMessage message)
+    {
+        if (string.IsNullOrWhiteSpace(message.Url))
+        {
+            throw new ArgumentException("URL is required.", nameof(message));
+        }
+
+        if (string.IsNullOrWhiteSpace(message.OutputPath))
+        {
+            throw new ArgumentException("Output path is required.", nameof(message));
+        }
+
+        // Validar URL
+        if (!Uri.TryCreate(message.Url, UriKind.Absolute, out var uri))
+        {
+            throw new ArgumentException("Invalid URL format.", nameof(message));
+        }
+
+        // Validar startTime/endTime
+        if (!string.IsNullOrEmpty(message.StartTime) && !string.IsNullOrEmpty(message.EndTime))
+        {
+            // Validação básica - formato será validado no worker
+            if (message.StartTime == message.EndTime)
+            {
+                throw new ArgumentException("Start time and end time cannot be equal.", nameof(message));
+            }
+        }
+    }
+}

--- a/src/Cutube.Api/appsettings.json
+++ b/src/Cutube.Api/appsettings.json
@@ -14,5 +14,14 @@
   },
   "HealthChecks": {
     "DiskSpaceMinRequiredGB": 1
+  },
+  "RabbitMq": {
+    "Host": "localhost",
+    "Port": 5672,
+    "VirtualHost": "/",
+    "UserName": "cutube",
+    "Password": "cutube123",
+    "RetryCount": 5,
+    "Timeout": 30
   }
 }

--- a/tests/Cutube.Api.Tests/Helpers/TestWebApplicationFactory.cs
+++ b/tests/Cutube.Api.Tests/Helpers/TestWebApplicationFactory.cs
@@ -1,21 +1,35 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Cutube.Api.Queuing;
+using Cutube.Api.Queuing.Messages;
+using Moq;
 
 namespace Cutube.Api.Tests.Helpers;
 
 /// <summary>
-/// Factory for creating a test instance of the API application
+/// Factory for creating a test instance of API application
 /// </summary>
 public class TestWebApplicationFactory : WebApplicationFactory<Program>
 {
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
+        // Set environment to Testing to skip MassTransit configuration
+        builder.UseEnvironment("Testing");
+
         builder.ConfigureServices(services =>
         {
-            // Services can be replaced with mocks here for testing
-            // Example: Replace real download service with a mock for faster tests
+            // Mock IQueueProducer for tests
+            var mockProducer = new Mock<IQueueProducer>();
+            mockProducer
+                .Setup(x => x.PublishDownloadAsync(It.IsAny<DownloadMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Guid.NewGuid().ToString);
+            mockProducer.Setup(x => x.IsConnected).Returns(true);
+
+            // Replace the real producer with the mock
+            services.AddSingleton<IQueueProducer>(mockProducer.Object);
         });
     }
 }


### PR DESCRIPTION
## Summary
Implemented RabbitMQ producer integration for asynchronous download processing, replacing the previous direct processing model. Downloads are now enqueued to RabbitMQ using MassTransit, enabling horizontal scaling and improved fault tolerance.
 ## Key Changes
- Created `IQueueProducer` interface and `RabbitMqProducer` implementation with MassTransit (`src/Cutube.Api/Queuing/`)
- Configured MassTransit for RabbitMQ with retry policies and connection management (`src/Cutube.Api/Program.cs`)
- Updated POST /api/downloads to enqueue messages instead of direct processing (`src/Cutube.Api/Endpoints/DownloadsEndpoints.cs`)
- Enhanced response DTOs with correlation ID, status URL, and timestamp (`src/Cutube.Api/DTOs/`)
- Updated frontend to handle new queue-based response structure (`cutube-web/hooks/`, `types/`)
- Added test mocks for IQueueProducer to isolate testing from RabbitMQ (`tests/Cutube.Api.Tests/`)
 ## Quality
- Tests passing: 166 tests (11 + 99 + 56)
- Skipped: 1 test (requires special OS permissions - justified)
- Build: Clean (pre-existing warnings unrelated to this PR)
##  Notes
- RabbitMQ credentials in appsettings.json are development defaults; use environment variables for production
- Worker service (bd-858.3) will consume these messages from the queue
- Correlation ID enables end-to-end tracking across API and worker