### PR TITLE
feat(worker/api): implement retry policy with exponential backoff and DLQ management (Cutube-858.5.1)

### DIFF
--- a/plans/fase-3.5.4-dashboard-dlq.md
+++ b/plans/fase-3.5.4-dashboard-dlq.md
@@ -1,0 +1,933 @@
+# Fase 3.5.4: Dashboard de Dead Letter Queue
+
+**Status:** 🎯 Planejamento
+**Épico:** Cutube-858 (Épico 3: Integração com RabbitMQ)
+**Duração:** 1-2 dias
+**Responsável:** Frontend Developer
+**Prioridade:** 🔥 Alta
+**Dependência:** ✅ Fase 3.5.3 (Endpoints de Reprocessamento) completa
+
+---
+
+## Objetivo
+
+Criar uma interface visual dedicada para gerenciar mensagens na **Dead Letter Queue (DLQ)**. O dashboard permitirá que administradores visualizem downloads que falharam permanentemente, vejam detalhes dos erros e reprocessem ou descartem mensagens manualmente.
+
+**Benefícios:**
+- ✅ **Visibilidade**: Admins podem ver facilmente todos os downloads na DLQ
+- ✅ **Ação Rápida**: Botões de Retry/Discard para operações manuais
+- ✅ **Detalhamento**: Informações completas do erro (tipo, mensagem, stack trace)
+- ✅ **Batch Operations**: Reprocessar todas as mensagens da DLQ de uma vez
+- ✅ **Contador de Retentativas**: Visualizar quantas vezes um download falhou
+- ✅ **UX Aprimorada**: Separação clara entre failed (retratável) e dead_letter (manual)
+
+---
+
+## Visão Arquitetural
+
+### Fluxo de Reprocessamento Manual
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    Fluxo de Reprocessamento Manual                    │
+│                                                                         │
+│  ┌──────────────┐                                                       │
+│  │   Monitor    │  1. Admin abre página /monitor                      │
+│  │    Page      │                                                       │
+│  └──────┬───────┘                                                       │
+│         │                                                               │
+│         ▼                                                               │
+│  ┌──────────────────────────────────────────────────────────────────┐   │
+│  │              DeadLetterQueue Component                         │   │
+│  │                                                                   │   │
+│  │  ┌────────────────────────────────────────────────────────┐    │   │
+│  │  │  Lista de mensagens na DLQ                         │    │   │
+│  │  │                                                        │    │   │
+│  │  │  ┌────────────────────────────────────────┐           │    │   │
+│  │  │  │ DLQ Card                              │           │    │   │
+│  │  │  │ • Correlation ID                      │           │    │   │
+│  │  │  │ • URL do vídeo                        │           │    │   │
+│  │  │  │ • Error Message (expansível)          │           │       │   │
+│  │  │  │ • Retry Count                         │           │    │   │
+│  │  │  │ • Timestamp                          │           │    │   │
+│  │  │  │                                    │           │    │   │
+│  │  │  │ [Retry] [Discard]                  │           │    │   │
+│  │  │  └────────────────────────────────────────┘           │    │   │
+│  │  └────────────────────────────────────────────────────────┘    │   │
+│  │                                                                   │   │
+│  │  [Retry All] [Refresh]                                         │   │
+│  └───────────────────────────────────────────────────────────────────┘   │
+│         │                                                               │
+│         │ 2. Admin clica em [Retry]                                    │
+│         ▼                                                               │
+│  ┌──────────────────────────────────────────────────────────────────┐   │
+│  │                    API Call                                    │   │
+│  │  POST /api/downloads/dlq/{correlationId}/retry               │   │
+│  └──────────────────────────────┬─────────────────────────────────┘   │
+│                               │                                      │
+│                               ▼                                      │
+│  ┌──────────────────────────────────────────────────────────────────┐   │
+│  │                   RabbitMQ Queue                               │   │
+│  │  Mensagem republicada em cutube.downloads                     │   │
+│  └───────────────────────────────────────────────────────────────────┘   │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Layout do Componente DeadLetterQueue
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    Dead Letter Queue Management                      │
+│                                                                         │
+│  ┌──────────────────────────────────────────────────────────────────┐  │
+│  │  Header                                                        │  │
+│  │  ⚠️ Dead Letter Queue (5 messages)                              │  │
+│  │  Messages that failed permanently and need manual intervention       │  │
+│  └───────────────────────────────────────────────────────────────────┘  │
+│                                                                         │
+│  ┌──────────────────────────────────────────────────────────────────┐  │
+│  │  Actions Bar                                                   │  │
+│  │  [🔄 Retry All] [🔄 Refresh] [🗑️ Clear All]                 │  │
+│  └───────────────────────────────────────────────────────────────────┘  │
+│                                                                         │
+│  ┌──────────────────────────────────────────────────────────────────┐  │
+│  │  ┌────────────────────────────────────────────────────────┐      │  │
+│  │  │ DLQ Card - Expanded Error View               │      │  │
+│  │  │                                                     │      │  │
+│  │  │ ┌──────────────────────────────────────────┐         │      │  │
+│  │  │ │ Header                                │         │      │  │
+│  │  │ │ 🎵 Amazing Video Title               │         │      │  │
+│  │  │ │ https://youtube.com/watch?v=abc123    │         │      │  │
+│  │  │ │ ⚠️ Dead Letter • Retry #3           │         │      │  │
+│  │  │ └──────────────────────────────────────────┘         │      │  │
+│  │  │                                                     │      │  │
+│  │  │ ┌──────────────────────────────────────────┐         │      │  │
+│  │  │ │ Error Details                          │         │      │  │
+│  │  │ │ 📌 Type: TransientException         │         │      │  │
+│  │  │ │ 💬 Message: Network timeout...        │         │      │  │
+│  │  │ │ ⏱️ Failed: 2 minutes ago           │         │      │  │
+│  │  │ │ [▼ Show Stack Trace]                 │         │      │  │
+│  │  │ └──────────────────────────────────────────┘         │      │  │
+│  │  │                                                     │      │  │
+│  │  │ ┌──────────────────────────────────────────┐         │      │  │
+│  │  │ │ Actions                                │         │      │  │
+│  │  │ │ [🔄 Retry] [🗑️ Discard]               │         │      │  │
+│  │  │ └──────────────────────────────────────────┘         │      │  │
+│  │  └─────────────────────────────────────────────────────┘      │  │
+│  └───────────────────────────────────────────────────────────────────┘  │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Estados e Transições UI
+
+```
+┌──────────┐     ┌──────────┐     ┌──────────────┐     ┌─────────────┐
+│  Queued  │────►│Processing│────►│   Completed  │     │             │
+└──────────┘     └────┬─────┘     └──────────────┘     │  Success    │
+                       │                                 └─────────────┘
+                       │
+                       ▼ Error temporário
+                ┌──────────────┐
+                │   Failed     │
+                │ (retryable)  │
+                └──────┬───────┘
+                       │
+                       │ 3 tentativas com backoff
+                       │
+                       ▼ Error permanente
+                ┌──────────────┐     ┌──────────────┐
+                │  DeadLetter  │────►│   Queued     │
+                │    (DLQ)     │     │  (retry)     │
+                └──────────────┘     └──────────────┘
+                       │
+                       ▼ Descartado
+                ┌──────────────┐
+                │  Cancelled  │
+                │  (discarded) │
+                └──────────────┘
+```
+
+### Diferença: Failed vs DeadLetter
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│               Distinção Visual: Failed vs DeadLetter                │
+│                                                                         │
+│  FAILED (retryable automatically)                                    │
+│  ┌────────────────────────────────────────────────────────┐             │
+│  │ ❌ Failed                                           │             │
+│  │    Error: Network timeout                              │             │
+│  │    Will retry automatically in 30s...                 │             │
+│  │    [View Details]                                     │             │
+│  └────────────────────────────────────────────────────────┘             │
+│                                                                         │
+│  DEAD LETTER (manual intervention required)                         │
+│  ┌────────────────────────────────────────────────────────┐             │
+│  │ ⚠️ Dead Letter                                      │             │
+│  │    Error: Video unavailable                           │             │
+│  │    Failed after 3 attempts                           │             │
+│  │    [🔄 Retry Now] [🗑️ Discard]                     │             │
+│  └────────────────────────────────────────────────────────┘             │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Tarefas
+
+---
+
+### 3.5.4.1 Criar API Client para DLQ
+
+**Estimativa:** 1-2 horas
+
+**Arquivos:**
+```
+cutube-web/
+  └── lib/
+      └── api.ts (atualizar)
+```
+
+#### 3.5.4.1.1 Adicionar métodos DLQ na API
+
+```typescript
+// cutube-web/lib/api.ts
+
+export const api = {
+  // ... métodos existentes ...
+
+  dlq: {
+    getAll: async (): Promise<DownloadListResponse> => {
+      return fetchApi<DownloadListResponse>("/api/downloads/dlq");
+    },
+
+    retry: async (correlationId: string): Promise<{ message: string; status: string }> => {
+      return fetchApi<{ message: string; status: string }>(
+        `/api/downloads/dlq/${correlationId}/retry`,
+        { method: "POST" }
+      );
+    },
+
+    retryAll: async (): Promise<{
+      message: string;
+      totalCount: number;
+      successCount: number;
+      failedCount: number;
+    }> => {
+      return fetchApi<{
+        message: string;
+        totalCount: number;
+        successCount: number;
+        failedCount: number;
+      }>("/api/downloads/dlq/retry-all", { method: "POST" });
+    },
+
+    discard: async (correlationId: string): Promise<void> => {
+      return fetchApi<void>(`/api/downloads/dlq/${correlationId}`, {
+        method: "DELETE",
+      });
+    },
+  },
+};
+```
+
+**Checklist:**
+- [ ] Adicionar seção `dlq` no objeto `api`
+- [ ] Implementar `dlq.getAll()` para buscar mensagens DLQ
+- [ ] Implementar `dlq.retry(correlationId)` para reprocessar mensagem
+- [ ] Implementar `dlq.retryAll()` para reprocessar todas
+- [ ] Implementar `dlq.discard(correlationId)` para descartar mensagem
+- [ ] Verificar tipos TypeScript compatíveis
+
+**Critérios de aceite:**
+- ✅ Todos os endpoints da DLQ estão mapeados
+- ✅ Tipos TypeScript corretos para requests/responses
+- ✅ Tratamento de erros apropriado
+- ✅ Código segue padrão existente do `api.ts`
+
+---
+
+### 3.5.4.2 Criar Hook Personalizado para DLQ
+
+**Estimativa:** 1-2 horas
+
+**Arquivos:**
+```
+cutube-web/
+  └── hooks/
+      └── use-dlq.ts (novo)
+```
+
+#### 3.5.4.2.1 Implementar hook useDlq
+
+```typescript
+// cutube-web/hooks/use-dlq.ts
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import type { MonitorDownloadStatus } from "@/types";
+import { api } from "@/lib/api";
+
+interface UseDlqReturn {
+  dlqMessages: MonitorDownloadStatus[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  retryMessage: (correlationId: string) => Promise<boolean>;
+  retryAll: () => Promise<{ totalCount: number; successCount: number; failedCount: number }>;
+  discardMessage: (correlationId: string) => Promise<boolean>;
+  lastUpdated: Date | null;
+}
+
+export function useDlq(refreshInterval = 10000): UseDlqReturn {
+  const [dlqMessages, setDlqMessages] = useState<MonitorDownloadStatus[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setError(null);
+      const response = await api.dlq.getAll();
+      setDlqMessages(response.downloads);
+      setLastUpdated(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const retryMessage = useCallback(async (correlationId: string) => {
+    try {
+      await api.dlq.retry(correlationId);
+      await fetchData(); // Refresh lista
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to retry");
+      return false;
+    }
+  }, [fetchData]);
+
+  const retryAll = useCallback(async () => {
+    try {
+      const result = await api.dlq.retryAll();
+      await fetchData(); // Refresh lista
+      return result;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to retry all");
+      return { totalCount: 0, successCount: 0, failedCount: 0 };
+    }
+  }, [fetchData]);
+
+  const discardMessage = useCallback(async (correlationId: string) => {
+    try {
+      await api.dlq.discard(correlationId);
+      await fetchData(); // Refresh lista
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to discard");
+      return false;
+    }
+  }, [fetchData]);
+
+  useEffect(() => {
+    fetchData();
+    const interval = setInterval(fetchData, refreshInterval);
+    return () => clearInterval(interval);
+  }, [fetchData, refreshInterval]);
+
+  return {
+    dlqMessages,
+    isLoading,
+    error,
+    refresh: fetchData,
+    retryMessage,
+    retryAll,
+    discardMessage,
+    lastUpdated,
+  };
+}
+```
+
+**Checklist:**
+- [ ] Criar hook `useDlq` com estado das mensagens
+- [ ] Implementar busca automática (polling)
+- [ ] Implementar `retryMessage` para retry individual
+- [ ] Implementar `retryAll` para retry em lote
+- [ ] Implementar `discardMessage` para descartar
+- [ ] Adicionar tratamento de erros
+- [ ] Exportar tipos TypeScript apropriados
+
+**Critérios de aceite:**
+- ✅ Hook busca mensagens da DLQ automaticamente
+- ✅ Operações de retry/discard atualizam o estado
+- ✅ Erros são propagados para o componente
+- ✅ Polling configurável (default: 10s)
+- ✅ TypeScript sem erros
+
+---
+
+### 3.5.4.3 Criar Componente DeadLetterQueue
+
+**Estimativa:** 3-4 horas
+
+**Arquivos:**
+```
+cutube-web/
+  └── components/
+      └── monitor/
+          └── dead-letter-queue.tsx (novo)
+          └── dlq-card.tsx (novo)
+```
+
+#### 3.5.4.3.1 Criar DlqCard (Card Individual)
+
+```typescript
+// cutube-web/components/monitor/dlq-card.tsx
+"use client";
+
+import type { MonitorDownloadStatus } from "@/types";
+import { useState } from "react";
+
+interface DlqCardProps {
+  download: MonitorDownloadStatus;
+  onRetry: (correlationId: string) => Promise<boolean>;
+  onDiscard: (correlationId: string) => Promise<boolean>;
+}
+
+export function DlqCard({ download, onRetry, onDiscard }: DlqCardProps) {
+  const [isRetrying, setIsRetrying] = useState(false);
+  const [isDiscarding, setIsDiscarding] = useState(false);
+  const [showStackTrace, setShowStackTrace] = useState(false);
+
+  const handleRetry = async () => {
+    setIsRetrying(true);
+    await onRetry(download.correlationId);
+    setIsRetrying(false);
+  };
+
+  const handleDiscard = async () => {
+    if (!confirm("Are you sure you want to discard this message?")) return;
+    setIsDiscarding(true);
+    await onDiscard(download.correlationId);
+    setIsDiscarding(false);
+  };
+
+  const timeSinceFailed = download.updatedAt
+    ? new Date(download.updatedAt).toLocaleString()
+    : "Unknown";
+
+  return (
+    <div className="bg-white rounded-lg shadow-md border-2 border-orange-300 p-4">
+      {/* Header */}
+      <div className="flex justify-between items-start mb-3">
+        <div className="flex-1 min-w-0">
+          <h3 className="font-semibold text-gray-800 truncate" title={download.url}>
+            🎵 {download.metadata?.title || "Untitled"}
+          </h3>
+          <p className="text-xs text-gray-500 truncate">{download.url}</p>
+        </div>
+        <span className="text-xs px-2 py-1 rounded-full bg-orange-100 text-orange-700 border border-orange-300">
+          ⚠️ Dead Letter • Retry #{download.retryCount}
+        </span>
+      </div>
+
+      {/* Error Details */}
+      <div className="mb-3 bg-orange-50 border border-orange-200 rounded p-3">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-sm font-semibold text-orange-800">Error Details</span>
+          <span className="text-xs text-gray-500">{timeSinceFailed}</span>
+        </div>
+        <p className="text-sm text-orange-700 mb-2">
+          💬 {download.errorMessage || "Unknown error"}
+        </p>
+
+        {/* Stack Trace (expansível) */}
+        {download.errorMessage && download.errorMessage.length > 100 && (
+          <button
+            onClick={() => setShowStackTrace(!showStackTrace)}
+            className="text-xs text-orange-600 hover:text-orange-800 underline"
+          >
+            {showStackTrace ? "▼ Hide" : "▶ Show"} Details
+          </button>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex gap-2 justify-end">
+        <button
+          onClick={handleRetry}
+          disabled={isRetrying}
+          className="px-3 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 disabled:opacity-50 flex items-center gap-1"
+        >
+          {isRetrying ? "🔄 Retrying..." : "🔄 Retry"}
+        </button>
+        <button
+          onClick={handleDiscard}
+          disabled={isDiscarding}
+          className="px-3 py-1.5 bg-red-600 text-white text-sm rounded hover:bg-red-700 disabled:opacity-50 flex items-center gap-1"
+        >
+          {isDiscarding ? "🗑️ Discarding..." : "🗑️ Discard"}
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+#### 3.5.4.3.2 Criar DeadLetterQueue (Lista de Cards)
+
+```typescript
+// cutube-web/components/monitor/dead-letter-queue.tsx
+"use client";
+
+import { useDlq } from "@/hooks/use-dlq";
+import { DlqCard } from "./dlq-card";
+
+interface DeadLetterQueueProps {
+  className?: string;
+}
+
+export function DeadLetterQueue({ className = "" }: DeadLetterQueueProps) {
+  const {
+    dlqMessages,
+    isLoading,
+    error,
+    refresh,
+    retryAll,
+    lastUpdated,
+  } = useDlq(10000); // Poll a cada 10s
+
+  const handleRetryAll = async () => {
+    const confirm = window.confirm(
+      `Are you sure you want to retry all ${dlqMessages.length} messages in the DLQ?`
+    );
+    if (!confirm) return;
+
+    const result = await retryAll();
+    alert(
+      `Batch retry completed:\n` +
+      `Total: ${result.totalCount}\n` +
+      `Success: ${result.successCount}\n` +
+      `Failed: ${result.failedCount}`
+    );
+  };
+
+  return (
+    <div className={`space-y-4 ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold flex items-center gap-2 text-orange-600">
+          <span>⚠️</span>
+          Dead Letter Queue
+          <span className="text-sm font-normal text-gray-500">
+            ({dlqMessages.length} messages)
+          </span>
+        </h2>
+        <div className="flex gap-2">
+          <button
+            onClick={handleRetryAll}
+            disabled={dlqMessages.length === 0}
+            className="px-3 py-1.5 bg-green-600 text-white text-sm rounded hover:bg-green-700 disabled:opacity-50 flex items-center gap-1"
+          >
+            🔄 Retry All
+          </button>
+          <button
+            onClick={refresh}
+            disabled={isLoading}
+            className="px-3 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 disabled:opacity-50 flex items-center gap-1"
+          >
+            {isLoading ? "🔄 Refreshing..." : "🔄 Refresh"}
+          </button>
+        </div>
+      </div>
+
+      {/* Error State */}
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <p className="text-red-700">{error}</p>
+        </div>
+      )}
+
+      {/* Loading State */}
+      {isLoading && dlqMessages.length === 0 ? (
+        <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center">
+          <p className="text-gray-500">Loading DLQ messages...</p>
+        </div>
+      ) : null}
+
+      {/* Empty State */}
+      {!isLoading && dlqMessages.length === 0 ? (
+        <div className="bg-green-50 border border-green-200 rounded-lg p-8 text-center">
+          <p className="text-green-700 text-lg mb-2">✅ No messages in Dead Letter Queue</p>
+          <p className="text-green-600 text-sm">All downloads are healthy!</p>
+        </div>
+      ) : null}
+
+      {/* DLQ Messages List */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {dlqMessages.map((download) => (
+          <DlqCard
+            key={download.correlationId}
+            download={download}
+            onRetry={async (id) => {
+              const result = await api.dlq.retry(id);
+              refresh();
+              return true;
+            }}
+            onDiscard={async (id) => {
+              await api.dlq.discard(id);
+              refresh();
+              return true;
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Footer Info */}
+      {lastUpdated && (
+        <div className="text-center text-xs text-gray-400 mt-4">
+          Last updated: {lastUpdated.toLocaleString()}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+**Checklist:**
+- [ ] Criar `DlqCard` componente individual
+- [ ] Adicionar visualização expandida de erros
+- [ ] Adicionar botões de Retry e Discard
+- [ ] Adicionar estado de loading durante operações
+- [ ] Criar `DeadLetterQueue` componente lista
+- [ ] Adicionar cabeçalho com contador de mensagens
+- [ ] Adicionar botão "Retry All" com confirmação
+- [ ] Adicionar loading e empty states
+- [ ] Adicionar polling automático (10s)
+- [ ] Seguir padrão de design existente (Tailwind)
+
+**Critérios de aceite:**
+- ✅ Componente lista todas as mensagens da DLQ
+- ✅ Cada card mostra detalhes completos do erro
+- ✅ Botões Retry e Discard funcionam corretamente
+- ✅ "Retry All" processa todas as mensagens em lote
+- ✅ Loading states durante operações
+- ✅ Confirmação antes de descartar mensagens
+- ✅ Visual responsivo (grid: 1→2→3 colunas)
+
+---
+
+### 3.5.4.4 Integrar DLQ Dashboard na Página Monitor
+
+**Estimativa:** 1-2 horas
+
+**Arquivos:**
+```
+cutube-web/
+  └── app/
+      └── monitor/
+          └── page.tsx (atualizar)
+```
+
+#### 3.5.4.4.1 Atualizar página Monitor
+
+```typescript
+// cutube-web/app/monitor/page.tsx
+"use client";
+
+import { useMonitor } from "@/hooks/use-monitor";
+import { useSignalR } from "@/hooks/use-signalr";
+import { MonitorMetrics } from "@/components/monitor/monitor-metrics";
+import { ActiveQueue } from "@/components/monitor/active-queue";
+import { FailedDownloads } from "@/components/monitor/failed-downloads";
+import { DeadLetterQueue } from "@/components/monitor/dead-letter-queue"; // NOVO
+import { useCallback } from "react";
+
+export default function MonitorPage() {
+  const {
+    activeDownloads,
+    failedDownloads,
+    metrics,
+    isLoading,
+    error,
+    refresh,
+    lastUpdated,
+  } = useMonitor(5000);
+
+  const handleStatusChanged = useCallback(() => {
+    refresh();
+  }, [refresh]);
+
+  const { isConnected } = useSignalR({
+    onDownloadStatusChanged: handleStatusChanged,
+    onDownloadCompleted: handleStatusChanged,
+    onDownloadFailed: handleStatusChanged,
+  });
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-gray-50 p-6">
+        <div className="max-w-7xl mx-auto">
+          <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+            <p className="text-4xl mb-2">❌</p>
+            <h2 className="text-lg font-semibold text-red-700 mb-2">Error loading monitor</h2>
+            <p className="text-red-600 mb-4">{error}</p>
+            <button
+              onClick={refresh}
+              className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6">
+      <div className="max-w-7xl mx-auto">
+        {/* Header */}
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6 gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-800">Monitor</h1>
+            <p className="text-gray-500">
+              System monitoring and queue status
+              {isConnected ? (
+                <span className="ml-2 text-green-600 font-medium">● Live</span>
+              ) : (
+                <span className="ml-2 text-yellow-600">○ Polling</span>
+              )}
+              {lastUpdated && (
+                <span className="ml-2 text-xs text-gray-400">
+                  Updated: {lastUpdated.toLocaleTimeString()}
+                </span>
+              )}
+            </p>
+          </div>
+          <button
+            onClick={refresh}
+            disabled={isLoading}
+            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
+          >
+            {isLoading ? "🔄 Refreshing..." : "🔄 Refresh"}
+          </button>
+        </div>
+
+        {/* Metrics */}
+        <MonitorMetrics metrics={metrics} />
+
+        {/* Active Queue */}
+        <div className="mb-8">
+          <ActiveQueue downloads={activeDownloads} />
+        </div>
+
+        {/* Failed Downloads */}
+        <div className="mb-8">
+          <FailedDownloads downloads={failedDownloads} />
+        </div>
+
+        {/* Dead Letter Queue - NOVO */}
+        <div className="mb-8">
+          <DeadLetterQueue />
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+**Checklist:**
+- [ ] Importar componente `DeadLetterQueue`
+- [ ] Adicionar seção DLQ abaixo de Failed Downloads
+- [ ] Manter consistência visual com outras seções
+- [ ] Testar integração com SignalR updates
+- [ ] Verificar responsividade
+
+**Critérios de aceite:**
+- ✅ Dashboard DLQ aparece na página Monitor
+- ✅ Layout consistente com outras seções
+- ✅ SignalR updates funcionam para DLQ
+- ✅ Polling não conflita com SignalR
+
+---
+
+### 3.5.4.5 Melhorar FailedDownloads para Separar DLQ
+
+**Estimativa:** 1-2 horas
+
+**Arquivos:**
+```
+cutube-web/
+  └── components/
+      └── monitor/
+          └── failed-downloads.tsx (atualizar)
+```
+
+#### 3.5.4.5.1 Atualizar componente FailedDownloads
+
+```typescript
+// cutube-web/components/monitor/failed-downloads.tsx
+"use client";
+
+import type { MonitorDownloadStatus } from "@/types";
+import { QueueStatusCard } from "./queue-status-card";
+
+interface FailedDownloadsProps {
+  downloads: MonitorDownloadStatus[];
+}
+
+export function FailedDownloads({ downloads }: FailedDownloadsProps) {
+  // Separar: failed (retryable) vs dead_letter (manual)
+  const failed = downloads.filter((d) => d.state === "failed");
+  const deadLetter = downloads.filter((d) => d.state === "dead_letter");
+
+  if (failed.length === 0 && deadLetter.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Failed (Retryable Automatically) */}
+      {failed.length > 0 && (
+        <>
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold flex items-center gap-2 text-red-600">
+              <span>❌</span>
+              Failed Downloads
+              <span className="text-sm font-normal text-gray-500">
+                (will retry automatically)
+              </span>
+            </h2>
+            <span className="inline-flex items-center px-2 py-1 bg-red-100 text-red-700 rounded text-sm">
+              {failed.length} messages
+            </span>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {failed.map((download) => (
+              <QueueStatusCard key={download.correlationId} download={download} />
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Dead Letter (Manual Intervention) */}
+      {deadLetter.length > 0 && (
+        <div className="mt-6 pt-6 border-t-2 border-gray-200">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-semibold flex items-center gap-2 text-orange-600">
+              <span>⚠️</span>
+              Dead Letter Queue
+              <span className="text-sm font-normal text-gray-500">
+                (requires manual intervention)
+              </span>
+            </h2>
+            <div className="text-sm">
+              <span className="inline-flex items-center px-2 py-1 bg-orange-100 text-orange-700 rounded">
+                {deadLetter.length} messages
+              </span>
+            </div>
+          </div>
+
+          <div className="bg-orange-50 border border-orange-200 rounded-lg p-4 mb-4">
+            <p className="text-sm text-orange-700">
+              <strong>⚠️ Attention:</strong> Messages in the Dead Letter Queue have failed
+              permanently and cannot be retried automatically. Please review each message and
+              decide whether to retry or discard it.
+            </p>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {deadLetter.map((download) => (
+              <QueueStatusCard key={download.correlationId} download={download} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+**Checklist:**
+- [ ] Separar visualmente `failed` de `dead_letter`
+- [ ] Adicionar aviso explicativo sobre DLQ
+- [ ] Manter cards existentes para dead_letter
+- [ ] Adicionar divider visual entre seções
+- [ ] Melhorar legibilidade com texto descritivo
+
+**Critérios de aceite:**
+- ✅ Failed downloads (automático) visualmente distinto de DLQ
+- ✅ Aviso claro sobre necessidade de intervenção manual
+- ✅ Cards dead_letter mostram informações completas
+- ✅ Layout responsivo mantido
+
+---
+
+## Checklist de Fase
+
+### Implementação
+- [ ] API client para endpoints DLQ criado
+- [ ] Hook `useDlq` implementado com polling
+- [ ] Componente `DlqCard` criado com ações
+- [ ] Componente `DeadLetterQueue` criado
+- [ ] Dashboard DLQ integrado na página Monitor
+- [ ] FailedDownloads atualizado para separar DLQ
+- [ ] Estados de loading e empty implementados
+
+### Testes
+- [ ] Listagem de mensagens DLQ funciona
+- [ ] Retry individual reprocessa mensagem corretamente
+- [ ] Retry All processa todas as mensagens
+- [ ] Discard remove mensagem da DLQ
+- [ ] Confirmações aparecem antes de ações destrutivas
+- [ ] Polling atualiza lista automaticamente
+- [ ] SignalR updates funcionam com DLQ
+
+### Design & UX
+- [ ] Cores e ícones consistentes (laranja para DLQ)
+- [ ] Cards responsivos em mobile (1 coluna)
+- [ ] Animações de loading suaves
+- [ ] Feedback visual imediato para ações
+- [ ] Acessibilidade (contraste, tamanhos)
+
+### Documentação
+- [ ] Comentários em código explicativos
+- [ ] Props dos componentes documentados
+- [ ] API client com JSDoc
+
+### Validação
+- [ ] Todos os critérios de aceite atendidos
+- [ ] Código segue padrões do projeto (Tailwind, TypeScript)
+- [ ] Sem erros TypeScript
+- [ ] Build funciona sem warnings
+- [ ] Testes manuais passam
+
+---
+
+## Notas
+
+- **Polling vs SignalR:** DLQ usa polling (10s) ao invés de SignalR para simplicidade, pois reprocessamentos são menos frequentes
+- **Confirmação:** Usar `window.confirm` para simplicidade; pode ser substituído por modal customizado depois
+- **Separação Visual:** Falhas automáticas (failed) vs manuais (dead_letter) devem ser visualmente distintas
+- **Batch Retry:** "Retry All" deve ter confirmação dupla para evitar operações acidentais
+- **Empty State:** Mostrar mensagem positiva quando DLQ está vazia ("All downloads are healthy!")
+
+---
+
+**Criado em:** 11/02/2026
+**Última atualização:** 11/02/2026
+
+---
+
+## Referências
+
+- [Fase 3.5: Retry & Dead Letter Queue](/home/willsantos/dev/Cutube/plans/fase-3.5-retry-dead-letter-queue.md)
+- [Frontend Design System](/home/willsantos/dev/Cutube/cutube-web/design-system.md)
+- [Épico 3: Integração com RabbitMQ](/home/willsantos/dev/Cutube/plans/epico-3-integracao-rabbitmq.md)

--- a/src/Cutube.Api/DTOs/MonitorDTOs.cs
+++ b/src/Cutube.Api/DTOs/MonitorDTOs.cs
@@ -79,6 +79,7 @@ public class UpdateStatusRequest
 {
     public required string State { get; init; }
     public string? ErrorMessage { get; init; }
+    public int? RetryCount { get; init; }
 }
 
 /// <summary>

--- a/src/Cutube.Api/Endpoints/DlqEndpoints.cs
+++ b/src/Cutube.Api/Endpoints/DlqEndpoints.cs
@@ -1,0 +1,165 @@
+using Cutube.Api.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Cutube.Api.Endpoints;
+
+/// <summary>
+/// Endpoints para gerenciamento da Dead Letter Queue.
+/// </summary>
+public static class DlqEndpoints
+{
+    public static void MapDlqEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/downloads/dlq")
+            .WithTags("Dead Letter Queue");
+
+        // GET /api/downloads/dlq - Listar mensagens na DLQ
+        group.MapGet("/", async (
+            DlqService dlqService,
+            CancellationToken ct) =>
+        {
+            var messages = await dlqService.GetDeadLetterMessagesAsync(ct);
+
+            return Results.Ok(new
+            {
+                TotalCount = messages.Count,
+                Messages = messages.Select(m => new
+                {
+                    m.CorrelationId,
+                    m.Url,
+                    State = m.Status.ToString().ToLowerInvariant(),
+                    m.ErrorMessage,
+                    m.RetryCount,
+                    m.CreatedAt,
+                    m.UpdatedAt
+                })
+            });
+        })
+        .WithName("GetDlqMessages")
+        .WithSummary("List all messages in Dead Letter Queue");
+
+        // POST /api/downloads/dlq/{correlationId}/retry - Reprocessar mensagem
+        group.MapPost("/{correlationId}/retry", async (
+            string correlationId,
+            DlqService dlqService,
+            ILogger<Program> logger,
+            CancellationToken ct) =>
+        {
+            try
+            {
+                var success = await dlqService.RetryAsync(correlationId, ct);
+
+                if (!success)
+                {
+                    return Results.NotFound(new
+                    {
+                        error = "Message not found or not in DLQ state",
+                        correlationId
+                    });
+                }
+
+                logger.LogInformation(
+                    "DLQ message retried: {CorrelationId}",
+                    correlationId);
+
+                return Results.Ok(new
+                {
+                    message = "Message requeued for processing",
+                    correlationId,
+                    status = "queued"
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(
+                    ex,
+                    "Failed to retry DLQ message: {CorrelationId}",
+                    correlationId);
+
+                return Results.Problem(
+                    detail: ex.Message,
+                    statusCode: 500,
+                    title: "Failed to retry message");
+            }
+        })
+        .WithName("RetryDlqMessage")
+        .WithSummary("Retry a message from Dead Letter Queue");
+
+        // POST /api/downloads/dlq/retry-all - Reprocessar todas as mensagens
+        group.MapPost("/retry-all", async (
+            DlqService dlqService,
+            ILogger<Program> logger,
+            CancellationToken ct) =>
+        {
+            try
+            {
+                var result = await dlqService.RetryAllAsync(ct);
+
+                logger.LogInformation(
+                    "DLQ batch retry completed. Total: {Total}, Success: {Success}, Failed: {Failed}",
+                    result.TotalCount, result.SuccessCount, result.FailedCount);
+
+                return Results.Ok(new
+                {
+                    message = "Batch retry completed",
+                    totalCount = result.TotalCount,
+                    successCount = result.SuccessCount,
+                    failedCount = result.FailedCount
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to execute batch retry");
+
+                return Results.Problem(
+                    detail: ex.Message,
+                    statusCode: 500,
+                    title: "Failed to retry messages");
+            }
+        })
+        .WithName("RetryAllDlqMessages")
+        .WithSummary("Retry all messages in Dead Letter Queue");
+
+        // DELETE /api/downloads/dlq/{correlationId} - Descartar mensagem
+        group.MapDelete("/{correlationId}", async (
+            string correlationId,
+            DlqService dlqService,
+            ILogger<Program> logger,
+            CancellationToken ct) =>
+        {
+            try
+            {
+                var success = await dlqService.DiscardAsync(correlationId, ct);
+
+                if (!success)
+                {
+                    return Results.NotFound(new
+                    {
+                        error = "Message not found",
+                        correlationId
+                    });
+                }
+
+                logger.LogInformation(
+                    "DLQ message discarded: {CorrelationId}",
+                    correlationId);
+
+                return Results.NoContent();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(
+                    ex,
+                    "Failed to discard DLQ message: {CorrelationId}",
+                    correlationId);
+
+                return Results.Problem(
+                    detail: ex.Message,
+                    statusCode: 500,
+                    title: "Failed to discard message");
+            }
+        })
+        .WithName("DiscardDlqMessage")
+        .WithSummary("Discard a message from Dead Letter Queue");
+    }
+}

--- a/src/Cutube.Api/Endpoints/StatusEndpoints.cs
+++ b/src/Cutube.Api/Endpoints/StatusEndpoints.cs
@@ -56,37 +56,56 @@ public static class StatusEndpoints
         .WithSummary("Get failed and dead letter downloads")
         .WithOpenApi();
 
-        // PATCH /api/downloads/{correlationId}/status - Worker callback
-        group.MapPatch("/{correlationId}/status", async (
-            string correlationId,
-            [FromBody] UpdateStatusRequest request,
-            IDownloadStatusRepository repository,
-            IHubContext<DownloadHub, IDownloadHubClient> hub,
-            CancellationToken ct) =>
-        {
-            if (!Enum.TryParse<DownloadStatus>(request.State, true, out var newState))
-            {
-                return Results.BadRequest(new { error = "Invalid state" });
-            }
+         // PATCH /api/downloads/{correlationId}/status - Worker callback
+         group.MapPatch("/{correlationId}/status", async (
+             string correlationId,
+             [FromBody] UpdateStatusRequest request,
+             IDownloadStatusRepository repository,
+             IHubContext<DownloadHub, IDownloadHubClient> hub,
+             CancellationToken ct) =>
+         {
+             if (!Enum.TryParse<DownloadStatus>(request.State, true, out var newState))
+             {
+                 return Results.BadRequest(new { error = "Invalid state" });
+             }
 
-            var download = await repository.GetByCorrelationIdAsync(correlationId, ct);
-            if (download == null)
-            {
-                return Results.NotFound(new { error = "Download not found", correlationId });
-            }
+             var download = await repository.GetByCorrelationIdAsync(correlationId, ct);
+             if (download == null)
+             {
+                 return Results.NotFound(new { error = "Download not found", correlationId });
+             }
 
-            await repository.UpdateStateAsync(correlationId, newState, ct);
+             await repository.UpdateAsync(correlationId, s =>
+             {
+                 s.Status = newState;
+                 s.ErrorMessage = request.ErrorMessage;
 
-            // Notify via SignalR
-            var groupName = DownloadHub.GetDownloadGroupName(correlationId);
-            await hub.Clients.Group(groupName)
-                .DownloadStatusChanged(correlationId, request.State);
+                 if (request.RetryCount.HasValue)
+                 {
+                     s.RetryCount = request.RetryCount.Value;
+                 }
 
-            return Results.NoContent();
-        })
-        .WithName("UpdateDownloadStatus")
-        .WithSummary("Update download status (worker callback)")
-        .WithOpenApi();
+                 if (newState == DownloadStatus.Downloading && s.StartedAt.HasValue == false)
+                 {
+                     s.StartedAt = DateTime.UtcNow;
+                 }
+
+                 if (newState is DownloadStatus.Completed or DownloadStatus.Failed or DownloadStatus.Cancelled or DownloadStatus.DeadLetter)
+                 {
+                     s.CompletedAt = DateTime.UtcNow;
+                 }
+             }, ct);
+
+             // Notify via SignalR
+             var groupName = DownloadHub.GetDownloadGroupName(correlationId);
+             await hub.Clients.Group(groupName)
+                 .DownloadStatusChanged(correlationId, request.State);
+
+             return Results.NoContent();
+         })
+         .WithName("UpdateDownloadStatus")
+         .WithSummary("Update download status (worker callback)")
+         .WithOpenApi();
 
         // POST /api/downloads/{correlationId}/progress - Worker progress callback
         group.MapPost("/{correlationId}/progress", async (

--- a/src/Cutube.Api/Program.cs
+++ b/src/Cutube.Api/Program.cs
@@ -70,12 +70,13 @@ builder.Services.AddSingleton<IVideoDownloader, YtDlpDownloader>();
 builder.Services.AddSingleton<IVideoProcessor, FfmpegProcessor>();
 builder.Services.AddSingleton<IVideoMetadataProvider, YtDlpMetadataProvider>();
 
-// API Services
-builder.Services.AddSingleton<IDownloadQueue, DownloadQueue>();
-builder.Services.AddSingleton<IDownloadStatusRepository, InMemoryStatusRepository>();
-builder.Services.AddSingleton<ConnectionTracker>();
-builder.Services.AddHostedService<BackgroundDownloadWorker>();
-builder.Services.AddHostedService<DownloadStatusCleanupService>();
+ // API Services
+ builder.Services.AddSingleton<IDownloadQueue, DownloadQueue>();
+ builder.Services.AddSingleton<IDownloadStatusRepository, InMemoryStatusRepository>();
+ builder.Services.AddSingleton<DlqService>();
+ builder.Services.AddSingleton<ConnectionTracker>();
+ builder.Services.AddHostedService<BackgroundDownloadWorker>();
+ builder.Services.AddHostedService<DownloadStatusCleanupService>();
 
 // RabbitMQ Configuration - Skip if running in tests
 if (!builder.Environment.IsEnvironment("Testing"))
@@ -142,10 +143,11 @@ app.MapHealthChecks("/health/ready", new Microsoft.AspNetCore.Diagnostics.Health
     Predicate = check => check.Tags.Contains("ready")
 });
 
-// Map endpoints
-app.MapDownloadsEndpoints();
-app.MapVideosEndpoints();
-app.MapStatusEndpoints();
+ // Map endpoints
+ app.MapDownloadsEndpoints();
+ app.MapVideosEndpoints();
+ app.MapStatusEndpoints();
+ app.MapDlqEndpoints();
 
 // Root endpoint
 app.MapGet("/", () => "Cutube API - Video Download Service");

--- a/src/Cutube.Api/Queuing/Messages/DownloadMessage.cs
+++ b/src/Cutube.Api/Queuing/Messages/DownloadMessage.cs
@@ -61,6 +61,11 @@ public record DownloadMessage
     /// Metadados adicionais (título, duração, thumbnail).
     /// </summary>
     public DownloadMetadata? Metadata { get; init; }
+
+    /// <summary>
+    /// Número de tentativas de processamento (para retry).
+    /// </summary>
+    public int RetryCount { get; init; } = 0;
 }
 
 /// <summary>
@@ -82,4 +87,9 @@ public record DownloadMetadata
     /// URL da thumbnail.
     /// </summary>
     public string? Thumbnail { get; init; }
+
+    /// <summary>
+    /// Nome do canal.
+    /// </summary>
+    public string? Channel { get; init; }
 }

--- a/src/Cutube.Api/Services/DlqService.cs
+++ b/src/Cutube.Api/Services/DlqService.cs
@@ -1,0 +1,185 @@
+using Cutube.Api.Models;
+using Cutube.Api.Queuing;
+using Cutube.Api.Queuing.Messages;
+using Microsoft.Extensions.Logging;
+
+namespace Cutube.Api.Services;
+
+/// <summary>
+/// Serviço para gerenciar a Dead Letter Queue.
+/// </summary>
+public class DlqService
+{
+    private readonly IDownloadStatusRepository _repository;
+    private readonly IQueueProducer _producer;
+    private readonly ILogger<DlqService> _logger;
+
+    public DlqService(
+        IDownloadStatusRepository repository,
+        IQueueProducer producer,
+        ILogger<DlqService> logger)
+    {
+        _repository = repository;
+        _producer = producer;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Lista todas as mensagens na DLQ (status DeadLetter).
+    /// </summary>
+    public async Task<IReadOnlyList<DownloadStatusRecord>> GetDeadLetterMessagesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        return await _repository.GetByStatesAsync(
+            new[] { DownloadStatus.DeadLetter },
+            cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Reprocessa uma mensagem da DLQ.
+    /// </summary>
+    public async Task<bool> RetryAsync(
+        string correlationId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation(
+            "Attempting to retry DLQ message: {CorrelationId}",
+            correlationId);
+
+        // Buscar o status atual
+        var status = await _repository.GetByCorrelationIdAsync(correlationId, cancellationToken);
+
+        if (status == null)
+        {
+            _logger.LogWarning(
+                "DLQ message not found: {CorrelationId}",
+                correlationId);
+            return false;
+        }
+
+        if (status.Status != DownloadStatus.DeadLetter && status.Status != DownloadStatus.Failed)
+        {
+            _logger.LogWarning(
+                "Message {CorrelationId} is not in DLQ state. Current state: {State}",
+                correlationId, status.Status);
+            return false;
+        }
+
+        // Criar nova mensagem para reprocessamento
+        var message = new DownloadMessage
+        {
+            MessageId = Guid.NewGuid().ToString(),
+            CorrelationId = correlationId, // Manter mesmo correlation ID para tracking
+            Url = status.Url,
+            StartTime = null,
+            EndTime = null,
+            OutputPath = status.OutputPath ?? "/tmp/downloads",
+            AudioOnly = status.AudioOnly,
+            OutputFilename = status.OutputFilename,
+            Priority = "normal",
+            CreatedAt = DateTime.UtcNow,
+            RetryCount = status.RetryCount + 1,
+            Metadata = new Queuing.Messages.DownloadMetadata
+            {
+                Title = status.Metadata?.Title,
+                Duration = status.Metadata?.Duration,
+                Thumbnail = status.Metadata?.Thumbnail,
+                Channel = status.Metadata?.Channel
+            }
+        };
+
+        // Republicar na fila
+        await _producer.PublishDownloadAsync(message, cancellationToken);
+
+        // Atualizar status
+        await _repository.UpdateAsync(correlationId, s =>
+        {
+            s.Status = DownloadStatus.Queued;
+            s.RetryCount++;
+            s.ErrorMessage = null;
+            s.UpdatedAt = DateTime.UtcNow;
+        }, cancellationToken);
+
+        _logger.LogInformation(
+            "DLQ message requeued successfully: {CorrelationId}, RetryCount: {RetryCount}",
+            correlationId, status.RetryCount + 1);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Remove uma mensagem da DLQ (descarta permanentemente).
+    /// </summary>
+    public async Task<bool> DiscardAsync(
+        string correlationId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation(
+            "Discarding DLQ message: {CorrelationId}",
+            correlationId);
+
+        var status = await _repository.GetByCorrelationIdAsync(correlationId, cancellationToken);
+
+        if (status == null)
+        {
+            return false;
+        }
+
+        // Atualizar status para Cancelled
+        await _repository.UpdateAsync(correlationId, s =>
+        {
+            s.Status = DownloadStatus.Cancelled;
+            s.ErrorMessage = "Discarded by user from DLQ";
+            s.UpdatedAt = DateTime.UtcNow;
+        }, cancellationToken);
+
+        _logger.LogInformation(
+            "DLQ message discarded: {CorrelationId}",
+            correlationId);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Reprocessa todas as mensagens da DLQ.
+    /// </summary>
+    public async Task<BatchRetryResult> RetryAllAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var messages = await GetDeadLetterMessagesAsync(cancellationToken);
+        var results = new BatchRetryResult();
+
+        foreach (var message in messages)
+        {
+            try
+            {
+                var success = await RetryAsync(message.CorrelationId, cancellationToken);
+                if (success)
+                    results.SuccessCount++;
+                else
+                    results.FailedCount++;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to retry message: {CorrelationId}",
+                    message.CorrelationId);
+                results.FailedCount++;
+            }
+        }
+
+        results.TotalCount = messages.Count;
+        return results;
+    }
+}
+
+/// <summary>
+/// Resultado de reprocessamento em lote.
+/// </summary>
+public class BatchRetryResult
+{
+    public int TotalCount { get; set; }
+    public int SuccessCount { get; set; }
+    public int FailedCount { get; set; }
+}

--- a/src/Cutube.Worker/Configuration/RetryPolicyOptions.cs
+++ b/src/Cutube.Worker/Configuration/RetryPolicyOptions.cs
@@ -1,0 +1,43 @@
+namespace Cutube.Worker.Configuration;
+
+/// <summary>
+/// Configurações da política de retry.
+/// </summary>
+public class RetryPolicyOptions
+{
+    public const string SectionName = "RetryPolicy";
+
+    /// <summary>
+    /// Número máximo de tentativas (default: 3).
+    /// </summary>
+    public int MaxRetries { get; set; } = 3;
+
+    /// <summary>
+    /// Delay inicial em segundos (default: 5).
+    /// </summary>
+    public int InitialDelaySeconds { get; set; } = 5;
+
+    /// <summary>
+    /// Multiplicador para backoff exponencial (default: 6).
+    /// </summary>
+    public double BackoffMultiplier { get; set; } = 6;
+
+    /// <summary>
+    /// Delay máximo em segundos (default: 120 = 2min).
+    /// </summary>
+    public int MaxDelaySeconds { get; set; } = 120;
+
+    /// <summary>
+    /// Calcula o delay para uma tentativa específica.
+    /// </summary>
+    public TimeSpan GetDelayForAttempt(int attemptNumber)
+    {
+        if (attemptNumber <= 1)
+            return TimeSpan.FromSeconds(InitialDelaySeconds);
+
+        var delay = InitialDelaySeconds * Math.Pow(BackoffMultiplier, attemptNumber - 1);
+        var clampedDelay = Math.Min(delay, MaxDelaySeconds);
+
+        return TimeSpan.FromSeconds(clampedDelay);
+    }
+}

--- a/src/Cutube.Worker/Consumers/DlqConsumer.cs
+++ b/src/Cutube.Worker/Consumers/DlqConsumer.cs
@@ -1,0 +1,40 @@
+using Cutube.Api.Queuing.Messages;
+using Cutube.Worker.Handlers;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+
+namespace Cutube.Worker.Consumers;
+
+/// <summary>
+/// Consumer dedicado para a Dead Letter Queue.
+/// Processa mensagens que falharam permanentemente.
+/// </summary>
+public class DlqConsumer : IConsumer<DownloadMessage>
+{
+    private readonly DeadLetterHandler _dlqHandler;
+    private readonly ILogger<DlqConsumer> _logger;
+
+    public DlqConsumer(
+        DeadLetterHandler dlqHandler,
+        ILogger<DlqConsumer> logger)
+    {
+        _dlqHandler = dlqHandler;
+        _logger = logger;
+    }
+
+    public async Task Consume(ConsumeContext<DownloadMessage> context)
+    {
+        _logger.LogInformation(
+            "Processing message from DLQ: {CorrelationId}",
+            context.Message.CorrelationId);
+
+        // Obter informações de erro do header MassTransit
+        var faultMessage = context.Headers.Get<string>("MT-Fault-Message");
+        var faultException = new Exception(faultMessage ?? "Unknown fault");
+
+        await _dlqHandler.HandleAsync(context, faultException);
+
+        // Acknowledge a mensagem (remover da DLQ após processar)
+        // A mensagem é mantida no repositório da API para reprocessamento manual
+    }
+}

--- a/src/Cutube.Worker/Consumers/DownloadConsumer.cs
+++ b/src/Cutube.Worker/Consumers/DownloadConsumer.cs
@@ -1,26 +1,35 @@
 using Cutube.Api.Queuing.Messages;
 using Cutube.Worker.Configuration;
+using Cutube.Worker.Exceptions;
+using Cutube.Worker.Handlers;
 using Cutube.Worker.Services;
 using MassTransit;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Cutube.Worker.Consumers;
 
 /// <summary>
-/// MassTransit consumer for processing download messages from RabbitMQ queue.
+/// Consumer que processa mensagens de download com retry automático.
 /// </summary>
 public class DownloadConsumer : IConsumer<DownloadMessage>
 {
     private readonly IDownloadProcessingService _processingService;
+    private readonly IDownloadStatusNotificationService _notificationService;
+    private readonly RetryHandler _retryHandler;
     private readonly ILogger<DownloadConsumer> _logger;
     private readonly WorkerOptions _options;
 
     public DownloadConsumer(
         IDownloadProcessingService processingService,
+        IDownloadStatusNotificationService notificationService,
+        RetryHandler retryHandler,
         ILogger<DownloadConsumer> logger,
         IOptions<WorkerOptions> options)
     {
         _processingService = processingService;
+        _notificationService = notificationService;
+        _retryHandler = retryHandler;
         _logger = logger;
         _options = options.Value;
     }
@@ -31,43 +40,120 @@ public class DownloadConsumer : IConsumer<DownloadMessage>
         var correlationId = message.CorrelationId;
 
         _logger.LogInformation(
-            "Received download message: {CorrelationId}, URL: {Url}",
-            correlationId,
-            message.Url);
+            "Processing download: {CorrelationId}, URL: {Url}, Attempt: {RetryCount}",
+            correlationId, message.Url, message.RetryCount);
 
         try
         {
-            // Validate message
-            ValidateMessage(message);
+            // Notificar início do processamento
+            await _notificationService.NotifyStatusAsync(correlationId, "processing", context.CancellationToken);
 
-            // Process download with timeout
-            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(_options.DownloadTimeoutMinutes));
+            // Executar download com retry
+            await _retryHandler.ExecuteAsync(
+                $"Download-{correlationId}",
+                async () => await ExecuteDownloadAsync(message, context.CancellationToken),
+                context.CancellationToken);
 
-            // Link cancellation of the context with the CTS
-            await using var registration = context.CancellationToken.Register(() => cts.Cancel());
-
-            await _processingService.ProcessDownloadAsync(message, cts.Token);
+            // Sucesso
+            await _notificationService.NotifyStatusAsync(correlationId, "completed", context.CancellationToken);
 
             _logger.LogInformation(
                 "Download completed successfully: {CorrelationId}",
                 correlationId);
         }
+        catch (TransientException ex)
+        {
+            // Todas as tentativas falharam - enviar para DLQ
+            _logger.LogError(
+                ex,
+                "Download failed after all retry attempts: {CorrelationId}. " +
+                "Sending to DLQ...",
+                correlationId);
+
+            await _notificationService.NotifyDeadLetterAsync(
+                correlationId,
+                ex.Message,
+                message.RetryCount + 1);
+
+            // Re-lançar para que MassTransit envie para DLQ
+            throw;
+        }
+        catch (PermanentException ex)
+        {
+            // Erro permanente - enviar direto para DLQ sem retry
+            _logger.LogError(
+                ex,
+                "Download failed with permanent error: {CorrelationId}. " +
+                "Sending to DLQ...",
+                correlationId);
+
+            await _notificationService.NotifyDeadLetterAsync(
+                correlationId,
+                ex.Message,
+                message.RetryCount);
+
+            throw;
+        }
         catch (OperationCanceledException)
         {
+            // Download cancelado pelo usuário
+            await _notificationService.NotifyStatusAsync(correlationId, "cancelled", context.CancellationToken);
             _logger.LogWarning(
                 "Download cancelled: {CorrelationId}",
                 correlationId);
-            throw; // Re-throw for MassTransit to handle (retry or DLQ)
+            throw;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex,
-                "Error processing download: {CorrelationId}. Error: {Error}",
-                correlationId,
-                ex.Message);
+            // Erro não esperado - tentar classificar
+            _logger.LogError(
+                ex,
+                "Unexpected error processing download: {CorrelationId}",
+                correlationId);
 
-            // Re-throw for MassTransit retry policy
+            var classified = ExceptionClassifier.ClassifyDownloadException(ex, message.Url);
+
+            if (classified is TransientException)
+            {
+                await _notificationService.NotifyDeadLetterAsync(
+                    correlationId,
+                    $"Failed after retries: {ex.Message}",
+                    message.RetryCount + 1);
+            }
+            else
+            {
+                await _notificationService.NotifyDeadLetterAsync(
+                    correlationId,
+                    ex.Message,
+                    message.RetryCount);
+            }
+
             throw;
+        }
+    }
+
+    private async Task ExecuteDownloadAsync(
+        DownloadMessage message,
+        CancellationToken cancellationToken)
+    {
+        // Validar mensagem
+        ValidateMessage(message);
+
+        // Processar download com timeout
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(_options.DownloadTimeoutMinutes));
+
+        // Link cancellation
+        await using var registration = cancellationToken.Register(() => cts.Cancel());
+
+        try
+        {
+            await _processingService.ProcessDownloadAsync(message, cts.Token);
+        }
+        catch (Exception ex)
+        {
+            // Classificar e relançar
+            var classified = ExceptionClassifier.ClassifyDownloadException(ex, message.Url);
+            throw classified;
         }
     }
 
@@ -75,17 +161,17 @@ public class DownloadConsumer : IConsumer<DownloadMessage>
     {
         if (string.IsNullOrWhiteSpace(message.Url))
         {
-            throw new ArgumentException("URL is required", nameof(message));
+            throw new PermanentException("URL is required");
         }
 
         if (!Uri.TryCreate(message.Url, UriKind.Absolute, out _))
         {
-            throw new ArgumentException("Invalid URL format", nameof(message));
+            throw new PermanentException("Invalid URL format");
         }
 
         if (string.IsNullOrWhiteSpace(message.OutputPath))
         {
-            throw new ArgumentException("Output path is required", nameof(message));
+            throw new PermanentException("Output path is required");
         }
     }
 }

--- a/src/Cutube.Worker/Exceptions/PermanentException.cs
+++ b/src/Cutube.Worker/Exceptions/PermanentException.cs
@@ -1,0 +1,11 @@
+namespace Cutube.Worker.Exceptions;
+
+/// <summary>
+/// Exceção que indica uma falha permanente que não deve ser retentada.
+/// </summary>
+public class PermanentException : Exception
+{
+    public PermanentException(string message) : base(message) { }
+    public PermanentException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/src/Cutube.Worker/Exceptions/TransientException.cs
+++ b/src/Cutube.Worker/Exceptions/TransientException.cs
@@ -1,0 +1,11 @@
+namespace Cutube.Worker.Exceptions;
+
+/// <summary>
+/// Exceção que indica uma falha transitória que pode ser resolvida com retry.
+/// </summary>
+public class TransientException : Exception
+{
+    public TransientException(string message) : base(message) { }
+    public TransientException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/src/Cutube.Worker/Handlers/DeadLetterHandler.cs
+++ b/src/Cutube.Worker/Handlers/DeadLetterHandler.cs
@@ -1,0 +1,92 @@
+using Cutube.Api.Queuing.Messages;
+using Cutube.Worker.Services;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+
+namespace Cutube.Worker.Handlers;
+
+/// <summary>
+/// Handler para processar mensagens que chegam na Dead Letter Queue.
+/// </summary>
+public class DeadLetterHandler
+{
+    private readonly IDownloadStatusNotificationService _notificationService;
+    private readonly ILogger<DeadLetterHandler> _logger;
+
+    public DeadLetterHandler(
+        IDownloadStatusNotificationService notificationService,
+        ILogger<DeadLetterHandler> logger)
+    {
+        _notificationService = notificationService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Processa uma mensagem que foi enviada para a DLQ.
+    /// </summary>
+    public async Task HandleAsync(
+        ConsumeContext<DownloadMessage> context,
+        Exception exception)
+    {
+        var message = context.Message;
+        var correlationId = message.CorrelationId;
+
+        _logger.LogError(
+            exception,
+            "Message moved to DLQ: {CorrelationId}, URL: {Url}, " +
+            "RetryCount: {RetryCount}, Error: {ErrorMessage}",
+            correlationId,
+            message.Url,
+            message.RetryCount,
+            exception.Message);
+
+        // Extrair informações detalhadas do erro
+        var errorDetails = ExtractErrorDetails(exception);
+
+        // Notificar API sobre a mensagem na DLQ
+        await _notificationService.NotifyDeadLetterAsync(
+            correlationId,
+            errorDetails,
+            message.RetryCount);
+
+        // Log estruturado para análise
+        _logger.LogInformation(
+            "DLQ Message Logged: {@DlqMessage}",
+            new
+            {
+                CorrelationId = correlationId,
+                MessageId = message.MessageId,
+                Url = message.Url,
+                RetryCount = message.RetryCount,
+                ErrorType = exception.GetType().Name,
+                ErrorMessage = exception.Message,
+                Timestamp = DateTime.UtcNow
+            });
+    }
+
+    private string ExtractErrorDetails(Exception exception)
+    {
+        var details = new List<string>
+        {
+            $"Type: {exception.GetType().Name}",
+            $"Message: {exception.Message}"
+        };
+
+        if (exception.InnerException != null)
+        {
+            details.Add($"Inner: {exception.InnerException.Message}");
+        }
+
+        // Extrair stack trace relevante (primeiras 5 linhas)
+        if (!string.IsNullOrEmpty(exception.StackTrace))
+        {
+            var lines = exception.StackTrace
+                .Split('\n')
+                .Take(5)
+                .Select(l => l.Trim());
+            details.Add($"Stack: {string.Join(" | ", lines)}");
+        }
+
+        return string.Join(" | ", details);
+    }
+}

--- a/src/Cutube.Worker/Handlers/RetryHandler.cs
+++ b/src/Cutube.Worker/Handlers/RetryHandler.cs
@@ -1,0 +1,181 @@
+using Cutube.Worker.Configuration;
+using Cutube.Worker.Exceptions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Cutube.Worker.Handlers;
+
+/// <summary>
+/// Handler responsável por executar operações com retry e backoff exponencial.
+/// </summary>
+public class RetryHandler
+{
+    private readonly RetryPolicyOptions _options;
+    private readonly ILogger<RetryHandler> _logger;
+
+    public RetryHandler(
+        IOptions<RetryPolicyOptions> options,
+        ILogger<RetryHandler> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Executa uma operação com retry automático para exceções transitórias.
+    /// </summary>
+    public async Task<T> ExecuteAsync<T>(
+        string operationName,
+        Func<Task<T>> operation,
+        CancellationToken cancellationToken = default)
+    {
+        var lastException = new Exception("Unknown error");
+
+        for (int attempt = 1; attempt <= _options.MaxRetries; attempt++)
+        {
+            try
+            {
+                _logger.LogDebug(
+                    "Executing {OperationName}, attempt {Attempt}/{MaxRetries}",
+                    operationName, attempt, _options.MaxRetries);
+
+                var result = await operation();
+
+                if (attempt > 1)
+                {
+                    _logger.LogInformation(
+                        "{OperationName} succeeded on attempt {Attempt}",
+                        operationName, attempt);
+                }
+
+                return result;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (TransientException ex)
+            {
+                lastException = ex;
+
+                if (attempt < _options.MaxRetries)
+                {
+                    var delay = _options.GetDelayForAttempt(attempt);
+                    _logger.LogWarning(
+                        ex,
+                        "{OperationName} failed with transient error on attempt {Attempt}. " +
+                        "Retrying in {DelaySeconds}s...",
+                        operationName, attempt, delay.TotalSeconds);
+
+                    await Task.Delay(delay, cancellationToken);
+                }
+                else
+                {
+                    _logger.LogError(
+                        ex,
+                        "{OperationName} failed after {MaxRetries} attempts. " +
+                        "Max retries exhausted.",
+                        operationName, _options.MaxRetries);
+                }
+            }
+            catch (PermanentException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Erros não classificados são considerados permanentes
+                _logger.LogError(
+                    ex,
+                    "{OperationName} failed with permanent error on attempt {Attempt}. " +
+                    "No retry will be attempted.",
+                    operationName, attempt);
+                throw new PermanentException(
+                    $"Permanent error in {operationName}: {ex.Message}", ex);
+            }
+        }
+
+        throw new TransientException(
+            $"{operationName} failed after {_options.MaxRetries} attempts",
+            lastException);
+    }
+
+    /// <summary>
+    /// Executa uma operação sem retorno com retry.
+    /// </summary>
+    public async Task ExecuteAsync(
+        string operationName,
+        Func<Task> operation,
+        CancellationToken cancellationToken = default)
+    {
+        await ExecuteAsync(operationName, async () =>
+        {
+            await operation();
+            return true;
+        }, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Extensões para classificar exceções.
+/// </summary>
+public static class ExceptionClassifier
+{
+    /// <summary>
+    /// Classifica uma exceção de download como transitória ou permanente.
+    /// </summary>
+    public static Exception ClassifyDownloadException(Exception ex, string url)
+    {
+        var message = ex.Message.ToLowerInvariant();
+        var innerMessage = ex.InnerException?.Message?.ToLowerInvariant() ?? "";
+
+        // Erros transitórios (network, timeout, rate limit)
+        var transientPatterns = new[]
+        {
+            "timeout",
+            "connection",
+            "network",
+            "unreachable",
+            "temporarily",
+            "rate limit",
+            "429",
+            "503",
+            "502",
+            "504",
+            "dns",
+            "name resolution",
+            "connection refused",
+            "no route to host"
+        };
+
+        // Erros permanentes (lógicos, configuração, permissões)
+        var permanentPatterns = new[]
+        {
+            "permission denied",
+            "not found",
+            "invalid",
+            "forbidden",
+            "401",
+            "403",
+            "404",
+            "disk full",
+            "no space",
+            "unauthorized",
+            "bad request",
+            "malformed"
+        };
+
+        if (transientPatterns.Any(p => message.Contains(p) || innerMessage.Contains(p)))
+        {
+            return new TransientException($"Transient error processing {url}: {ex.Message}", ex);
+        }
+
+        if (permanentPatterns.Any(p => message.Contains(p) || innerMessage.Contains(p)))
+        {
+            return new PermanentException($"Permanent error processing {url}: {ex.Message}", ex);
+        }
+
+        // Por padrão, erros de processamento são transitórios (yt-dlp pode falhar intermitentemente)
+        return new TransientException($"Processing error for {url}: {ex.Message}", ex);
+    }
+}

--- a/src/Cutube.Worker/Program.cs
+++ b/src/Cutube.Worker/Program.cs
@@ -39,13 +39,15 @@ IHost host = Host.CreateDefaultBuilder(args)
         // Domain services
         services.AddSingleton<IDownloadProcessingService, DownloadProcessingService>();
 
-        // Retry Handler
+        // Handlers
         services.AddSingleton<RetryHandler>();
+        services.AddSingleton<DeadLetterHandler>();
 
         // MassTransit (Consumer)
         services.AddMassTransit(x =>
         {
             x.AddConsumer<DownloadConsumer>();
+            x.AddConsumer<DlqConsumer>();
 
             x.UsingRabbitMq((context, cfg) =>
             {
@@ -53,6 +55,7 @@ IHost host = Host.CreateDefaultBuilder(args)
 
                 cfg.Host($"amqp://{rabbitMqConfig.UserName}:{rabbitMqConfig.Password}@{rabbitMqConfig.Host}:{rabbitMqConfig.Port}{rabbitMqConfig.VirtualHost}");
 
+                // Configurar endpoint principal com DLQ
                 cfg.ReceiveEndpoint(RabbitMqConfig.DownloadsQueue, e =>
                 {
                     e.ConfigureConsumer<DownloadConsumer>(context);
@@ -67,6 +70,13 @@ IHost host = Host.CreateDefaultBuilder(args)
                     // Configurar DLQ usando argumentos da fila RabbitMQ
                     e.SetQueueArgument("x-dead-letter-exchange", RabbitMqConfig.DlqExchange);
                     e.SetQueueArgument("x-dead-letter-routing-key", RabbitMqConfig.DlqRoutingKey);
+                });
+
+                // Configurar endpoint da DLQ
+                cfg.ReceiveEndpoint(RabbitMqConfig.DownloadsDlqQueue, e =>
+                {
+                    e.ConfigureConsumer<DlqConsumer>(context);
+                    e.PrefetchCount = 1; // Processar DLQ um por vez
                 });
             });
         });

--- a/src/Cutube.Worker/Program.cs
+++ b/src/Cutube.Worker/Program.cs
@@ -1,5 +1,6 @@
 using Cutube.Worker.Configuration;
 using Cutube.Worker.Consumers;
+using Cutube.Worker.Handlers;
 using Cutube.Worker.Services;
 using MassTransit;
 using Polly;
@@ -22,6 +23,10 @@ IHost host = Host.CreateDefaultBuilder(args)
             context.Configuration.GetSection(WorkerOptions.SectionName)
         );
 
+        services.Configure<RetryPolicyOptions>(
+            context.Configuration.GetSection(RetryPolicyOptions.SectionName)
+        );
+
         // HttpClient for API communication
         services.AddHttpClient<IDownloadStatusNotificationService, DownloadStatusNotificationService>(client =>
         {
@@ -34,6 +39,9 @@ IHost host = Host.CreateDefaultBuilder(args)
         // Domain services
         services.AddSingleton<IDownloadProcessingService, DownloadProcessingService>();
 
+        // Retry Handler
+        services.AddSingleton<RetryHandler>();
+
         // MassTransit (Consumer)
         services.AddMassTransit(x =>
         {
@@ -45,23 +53,20 @@ IHost host = Host.CreateDefaultBuilder(args)
 
                 cfg.Host($"amqp://{rabbitMqConfig.UserName}:{rabbitMqConfig.Password}@{rabbitMqConfig.Host}:{rabbitMqConfig.Port}{rabbitMqConfig.VirtualHost}");
 
-                cfg.ReceiveEndpoint("cutube.downloads", e =>
+                cfg.ReceiveEndpoint(RabbitMqConfig.DownloadsQueue, e =>
                 {
                     e.ConfigureConsumer<DownloadConsumer>(context);
 
-                    // Prefetch count: 1 message at a time (avoids overload)
-                    e.PrefetchCount = 1;
+                    // Prefetch count
+                    e.PrefetchCount = RabbitMqConfig.PrefetchCount;
 
                     // Concurrent message limit
                     var workerOptions = context.GetRequiredService<Microsoft.Extensions.Options.IOptions<WorkerOptions>>().Value;
                     e.ConcurrentMessageLimit = workerOptions.MaxConcurrentDownloads;
 
-                    // Retry policy: 3 attempts with exponential backoff
-                    e.UseMessageRetry(r =>
-                    {
-                        r.Intervals(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(30), TimeSpan.FromMinutes(2));
-                        r.Handle<Exception>();
-                    });
+                    // Configurar DLQ usando argumentos da fila RabbitMQ
+                    e.SetQueueArgument("x-dead-letter-exchange", RabbitMqConfig.DlqExchange);
+                    e.SetQueueArgument("x-dead-letter-routing-key", RabbitMqConfig.DlqRoutingKey);
                 });
             });
         });

--- a/src/Cutube.Worker/Services/DownloadStatusNotificationService.cs
+++ b/src/Cutube.Worker/Services/DownloadStatusNotificationService.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 namespace Cutube.Worker.Services;
 
 /// <summary>
-/// Implementation of the status notification service via HTTP callbacks to the API.
+/// Implementation of status notification service via HTTP callbacks to the API.
 /// </summary>
 public class DownloadStatusNotificationService : IDownloadStatusNotificationService
 {
@@ -59,7 +59,7 @@ public class DownloadStatusNotificationService : IDownloadStatusNotificationServ
         }
         catch (Exception ex)
         {
-            // Don't throw - notification failure should not break the download
+            // Don't throw - notification failure should not break download
             _logger.LogError(ex,
                 "Error notifying status: {CorrelationId}",
                 correlationId);
@@ -105,9 +105,57 @@ public class DownloadStatusNotificationService : IDownloadStatusNotificationServ
         }
         catch (Exception ex)
         {
-            // Don't throw - notification failure should not break the download
+            // Don't throw - notification failure should not break download
             _logger.LogDebug(ex,
                 "Error notifying progress: {CorrelationId}",
+                correlationId);
+        }
+    }
+
+    public async Task NotifyDeadLetterAsync(
+        string correlationId,
+        string errorMessage,
+        int retryCount,
+        CancellationToken cancellationToken = default)
+    {
+        var url = $"/api/downloads/{correlationId}/status";
+
+        var payload = new
+        {
+            state = "deadletter",
+            errorMessage,
+            retryCount
+        };
+
+        try
+        {
+            var content = new StringContent(
+                JsonSerializer.Serialize(payload),
+                Encoding.UTF8,
+                "application/json");
+
+            var response = await _httpClient.PatchAsync(url, content, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Failed to notify dead letter status: {CorrelationId}, Status: {StatusCode}",
+                    correlationId,
+                    response.StatusCode);
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "Dead letter status notified: {CorrelationId}, RetryCount: {RetryCount}",
+                    correlationId,
+                    retryCount);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Don't throw - notification failure should not break download
+            _logger.LogError(ex,
+                "Error notifying dead letter status: {CorrelationId}",
                 correlationId);
         }
     }

--- a/src/Cutube.Worker/Services/IDownloadStatusNotificationService.cs
+++ b/src/Cutube.Worker/Services/IDownloadStatusNotificationService.cs
@@ -25,4 +25,13 @@ public interface IDownloadStatusNotificationService
         long? totalBytes = null,
         string? eta = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Notify that a download has been moved to the Dead Letter Queue.
+    /// </summary>
+    Task NotifyDeadLetterAsync(
+        string correlationId,
+        string errorMessage,
+        int retryCount,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Cutube.Worker/appsettings.json
+++ b/src/Cutube.Worker/appsettings.json
@@ -22,6 +22,12 @@
     "EnableGracefulShutdown": true,
     "GracefulShutdownTimeoutSeconds": 30
   },
+  "RetryPolicy": {
+    "MaxRetries": 3,
+    "InitialDelaySeconds": 5,
+    "BackoffMultiplier": 6,
+    "MaxDelaySeconds": 120
+  },
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
     "MinimumLevel": {


### PR DESCRIPTION
## Summary
Implements exponential backoff retry policy for download failures and complete Dead Letter Queue (DLQ) management system. Downloads now automatically retry on transient errors (network timeouts, rate limits) with configurable backoff (5s → 30s → 120s max), while permanent errors move directly to DLQ for manual intervention.

## Key Changes
- **RetryHandler** with exponential backoff algorithm (src/Cutube.Worker/Handlers/RetryHandler.cs)
- **TransientException/PermanentException** for error classification (src/Cutube.Worker/Exceptions/)
- **DLQ endpoints**: GET/POST retry/DELETE for manual reprocessing (src/Cutube.Api/Endpoints/DlqEndpoints.cs)
- **DownloadConsumer** integration with retry policy (src/Cutube.Worker/Consumers/DownloadConsumer.cs)
- **Status updates** now include RetryCount tracking (src/Cutube.Api/Endpoints/StatusEndpoints.cs)
- Configuration for retry policy (MaxRetries: 3, InitialDelay: 5s, Multiplier: 6x)

## Quality
Tests passing: 166 tests (11 + 99 + 56)
Skipped: 1 test (requires OS permissions - justified)
Build: Clean (only pre-existing ASPDEPR002/NU1510 warnings)

## Notes
- Manual DLQ dashboard plan included (plans/fase-3.5.4-dashboard-dlq.md)
- Error classification patterns cover network (transient) vs permission/404 (permanent)
- All retry attempts logged at appropriate levels (Debug/Info/Warning/Error)