### PR TITLE
feat(installer): add CLI installer scripts and docs (Cutube-crz)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,46 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - docs/**
+      - scripts/install.sh
+      - scripts/install.ps1
+      - .github/workflows/deploy-pages.yml
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Prepare Pages content
+        run: |
+          cp scripts/install.sh docs/install.sh
+          cp scripts/install.ps1 docs/install.ps1
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ O Cutube detectará automaticamente e usará sua versão se for mais recente que
 6. Enjoy!
 7. (Opcional) Se quiser, pode adicionar o executável do programa no PATH do seu sistema operacional para poder executar o programa de qualquer lugar
 
+## Instalacao do CLI
+
+Para instalacao automatica em Linux/macOS/Windows, use os scripts em `scripts/install.sh` e `scripts/install.ps1`.
+
+- Pagina de instalacao: `https://willsantos.github.io/Cutube/`
+- Guia completo: `docs/installation.md`
+
 ## RabbitMQ Setup
 
 O Cutube usa RabbitMQ para processamento assíncrono de downloads. Veja a [documentação completa](docs/setup-rabbitmq.md) para instruções detalhadas.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cutube CLI Installer</title>
+  <style>
+    :root {
+      --bg: #f5f8ff;
+      --surface: #ffffff;
+      --ink: #142033;
+      --muted: #49607a;
+      --accent: #0d6efd;
+      --accent-soft: #eaf2ff;
+      --border: #d9e3f1;
+      --code-bg: #0f1a2b;
+      --code-ink: #e7eef9;
+      --ok: #0a7d33;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: "Segoe UI", "SF Pro Text", "Helvetica Neue", sans-serif;
+      background: radial-gradient(circle at top right, #e8f0ff 0%, var(--bg) 45%, #f8fbff 100%);
+      color: var(--ink);
+      line-height: 1.6;
+      min-height: 100vh;
+      padding: 24px;
+    }
+
+    main {
+      max-width: 860px;
+      margin: 0 auto;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      box-shadow: 0 14px 44px rgba(20, 32, 51, 0.08);
+      overflow: hidden;
+    }
+
+    header {
+      padding: 30px 24px 22px;
+      background: linear-gradient(140deg, #f9fbff 0%, #eef4ff 100%);
+      border-bottom: 1px solid var(--border);
+    }
+
+    h1 {
+      margin: 0 0 10px;
+      font-size: clamp(1.7rem, 2.3vw, 2.2rem);
+      line-height: 1.2;
+    }
+
+    p {
+      margin: 0;
+      color: var(--muted);
+    }
+
+    section {
+      padding: 24px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    section:last-child { border-bottom: 0; }
+
+    h2 {
+      margin: 0 0 12px;
+      font-size: 1.15rem;
+    }
+
+    pre {
+      margin: 0;
+      background: var(--code-bg);
+      color: var(--code-ink);
+      padding: 14px;
+      border-radius: 10px;
+      overflow-x: auto;
+      font-size: 0.92rem;
+    }
+
+    code {
+      font-family: "Cascadia Code", "Fira Code", monospace;
+    }
+
+    .badge {
+      display: inline-block;
+      font-size: 0.78rem;
+      font-weight: 700;
+      color: var(--ok);
+      background: #e8faef;
+      padding: 5px 10px;
+      border-radius: 999px;
+      margin-bottom: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    ul {
+      margin: 0;
+      padding-left: 18px;
+      color: var(--muted);
+    }
+
+    a {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    a:hover { text-decoration: underline; }
+
+    @media (max-width: 640px) {
+      body { padding: 12px; }
+      section, header { padding: 18px 16px; }
+      pre { font-size: 0.84rem; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <span class="badge">Cutube CLI</span>
+      <h1>Instalador oficial</h1>
+      <p>Instale o Cutube com um comando em Linux, macOS ou Windows.</p>
+    </header>
+
+    <section>
+      <h2>Linux e macOS</h2>
+      <pre><code>curl -fsSL https://willsantos.github.io/Cutube/install.sh | bash</code></pre>
+    </section>
+
+    <section>
+      <h2>Windows (PowerShell)</h2>
+      <pre><code>iwr -useb https://willsantos.github.io/Cutube/install.ps1 | iex</code></pre>
+    </section>
+
+    <section>
+      <h2>Fallback (Raw GitHub)</h2>
+      <pre><code>curl -fsSL https://raw.githubusercontent.com/willsantos/Cutube/main/scripts/install.sh | bash</code></pre>
+      <pre style="margin-top: 10px;"><code>iwr -useb https://raw.githubusercontent.com/willsantos/Cutube/main/scripts/install.ps1 | iex</code></pre>
+    </section>
+
+    <section>
+      <h2>Proximos passos</h2>
+      <ul>
+        <li>Confirme com <code>cutube --version</code>.</li>
+        <li>Veja instalacao manual e troubleshooting na <a href="https://github.com/willsantos/Cutube/blob/main/docs/installation.md">documentacao completa</a>.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,81 @@
+# Instalacao do Cutube CLI
+
+## Instalacao rapida
+
+### Linux e macOS
+
+```bash
+curl -fsSL https://willsantos.github.io/Cutube/install.sh | bash
+```
+
+Fallback (Raw GitHub):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/willsantos/Cutube/main/scripts/install.sh | bash
+```
+
+### Windows (PowerShell)
+
+```powershell
+iwr -useb https://willsantos.github.io/Cutube/install.ps1 | iex
+```
+
+Fallback (Raw GitHub):
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/willsantos/Cutube/main/scripts/install.ps1 | iex
+```
+
+## Instalacao manual
+
+1. Acesse as releases: https://github.com/willsantos/Cutube/releases
+2. Baixe o pacote da sua plataforma.
+3. Extraia e mova o executavel para uma pasta no PATH.
+
+Exemplo Linux:
+
+```bash
+tar -xzf cutube-linux-amd64.tar.gz
+sudo install -m 755 cutube /usr/local/bin/cutube
+```
+
+## Dependencias opcionais
+
+- `yt-dlp` (ou `youtube-dl`) para metadados e fluxos adicionais
+- `ffmpeg` para processamento multimidia
+
+Exemplos:
+
+```bash
+# macOS
+brew install ffmpeg yt-dlp
+
+# Ubuntu/Debian
+sudo apt install ffmpeg
+python3 -m pip install -U yt-dlp
+```
+
+```powershell
+# Windows (winget)
+winget install yt-dlp.yt-dlp Gyan.FFmpeg
+```
+
+## Verificacao
+
+```bash
+cutube --version
+cutube --help
+```
+
+## Desinstalacao
+
+### Linux e macOS
+
+```bash
+sudo rm -f /usr/local/bin/cutube
+rm -f ~/.local/bin/cutube
+```
+
+### Windows
+
+Remova `cutube.exe` da pasta de instalacao e, se quiser, limpe a entrada de PATH correspondente.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,155 @@
+$ErrorActionPreference = 'Stop'
+
+$Repo = 'willsantos/Cutube'
+$BinaryName = 'cutube.exe'
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "[INFO] $Message" -ForegroundColor Green
+}
+
+function Write-WarnMsg {
+    param([string]$Message)
+    Write-Host "[WARN] $Message" -ForegroundColor Yellow
+}
+
+function Write-ErrorMsg {
+    param([string]$Message)
+    Write-Host "[ERROR] $Message" -ForegroundColor Red
+}
+
+function Get-ArchitectureName {
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    switch ($arch) {
+        'X64' { return 'amd64' }
+        'Arm64' { return 'arm64' }
+        default {
+            throw "Unsupported architecture: $arch"
+        }
+    }
+}
+
+function Get-LatestVersion {
+    $apiUrl = "https://api.github.com/repos/$Repo/releases/latest"
+    $response = Invoke-RestMethod -Uri $apiUrl -Method Get
+    if (-not $response.tag_name) {
+        throw 'Could not detect latest release tag.'
+    }
+    return [string]$response.tag_name
+}
+
+function Get-InstallDir {
+    $windowsIdentity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $windowsPrincipal = New-Object Security.Principal.WindowsPrincipal($windowsIdentity)
+    $isAdmin = $windowsPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+    if ($isAdmin) {
+        return [System.IO.Path]::Combine($env:ProgramFiles, 'Cutube')
+    }
+
+    return [System.IO.Path]::Combine($env:LocalAppData, 'Programs', 'Cutube')
+}
+
+function Add-ToPath {
+    param(
+        [string]$Directory,
+        [bool]$MachineScope
+    )
+
+    $target = if ($MachineScope) { 'Machine' } else { 'User' }
+    $pathValue = [Environment]::GetEnvironmentVariable('Path', $target)
+    $entries = @()
+    if ($pathValue) {
+        $entries = $pathValue.Split(';')
+    }
+
+    if ($entries -contains $Directory) {
+        return
+    }
+
+    $newPath = if ([string]::IsNullOrWhiteSpace($pathValue)) {
+        $Directory
+    }
+    else {
+        "$pathValue;$Directory"
+    }
+
+    [Environment]::SetEnvironmentVariable('Path', $newPath, $target)
+    $env:Path = "$env:Path;$Directory"
+}
+
+function Check-Dependencies {
+    $missing = @()
+
+    if (-not (Get-Command yt-dlp -ErrorAction SilentlyContinue) -and -not (Get-Command youtube-dl -ErrorAction SilentlyContinue)) {
+        $missing += 'yt-dlp'
+    }
+
+    if (-not (Get-Command ffmpeg -ErrorAction SilentlyContinue)) {
+        $missing += 'ffmpeg'
+    }
+
+    if ($missing.Count -eq 0) {
+        Write-Info 'Optional dependencies detected (yt-dlp/ffmpeg).'
+        return
+    }
+
+    Write-WarnMsg "Missing dependencies: $($missing -join ', ')"
+    Write-Info 'Install hint: winget install yt-dlp.yt-dlp Gyan.FFmpeg'
+}
+
+try {
+    Write-Host ''
+    Write-Host 'Cutube CLI Installer (Windows)'
+    Write-Host ''
+
+    $arch = Get-ArchitectureName
+    Write-Info "Detected architecture: $arch"
+
+    if ($arch -ne 'amd64') {
+        throw "No Windows release available for $arch at this time."
+    }
+
+    $version = Get-LatestVersion
+    Write-Info "Latest version: $version"
+
+    $assetName = 'cutube-windows-amd64.exe.zip'
+    $downloadUrl = "https://github.com/$Repo/releases/download/$version/$assetName"
+
+    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
+    New-Item -ItemType Directory -Path $tempDir | Out-Null
+
+    $zipPath = Join-Path $tempDir $assetName
+    Write-Info "Downloading $assetName"
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $zipPath
+
+    Expand-Archive -Path $zipPath -DestinationPath $tempDir -Force
+
+    $sourceExe = Join-Path $tempDir $BinaryName
+    if (-not (Test-Path $sourceExe)) {
+        throw "Executable not found in package: $BinaryName"
+    }
+
+    $installDir = Get-InstallDir
+    $machineScope = $installDir.StartsWith($env:ProgramFiles)
+
+    if (-not (Test-Path $installDir)) {
+        New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+    }
+
+    $targetExe = Join-Path $installDir $BinaryName
+    Copy-Item -Path $sourceExe -Destination $targetExe -Force
+    Add-ToPath -Directory $installDir -MachineScope:$machineScope
+
+    Check-Dependencies
+
+    Write-Info "Installed at $targetExe"
+    Write-Host ''
+    Write-Host 'Use: cutube --help'
+
+    Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+catch {
+    Write-ErrorMsg $_.Exception.Message
+    exit 1
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO="willsantos/Cutube"
+BINARY_NAME="cutube"
+DEFAULT_INSTALL_DIR="/usr/local/bin"
+FALLBACK_INSTALL_DIR="$HOME/.local/bin"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log_info() {
+  printf "%b\n" "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+  printf "%b\n" "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+  printf "%b\n" "${RED}[ERROR]${NC} $1" >&2
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    log_error "Required command not found: $1"
+    exit 1
+  fi
+}
+
+detect_platform() {
+  local os arch
+
+  case "$(uname -s)" in
+    Linux*) os="linux" ;;
+    Darwin*) os="macos" ;;
+    *)
+      log_error "Unsupported operating system for this script: $(uname -s)"
+      log_error "Para Windows, use: iwr -useb https://willsantos.github.io/Cutube/install.ps1 | iex"
+      exit 1
+      ;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64|amd64) arch="amd64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *)
+      log_error "Unsupported architecture: $(uname -m)"
+      exit 1
+      ;;
+  esac
+
+  printf "%s-%s" "$os" "$arch"
+}
+
+http_get() {
+  local url="$1"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO- "$url"
+  else
+    log_error "curl or wget is required for downloads"
+    exit 1
+  fi
+}
+
+download_file() {
+  local url="$1"
+  local output="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$output"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q "$url" -O "$output"
+  else
+    log_error "curl or wget is required for downloads"
+    exit 1
+  fi
+}
+
+get_latest_version() {
+  local api_url="https://api.github.com/repos/${REPO}/releases/latest"
+  local version
+
+  version="$(http_get "$api_url" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+  if [ -z "$version" ]; then
+    log_error "Could not detect latest release version from ${api_url}"
+    exit 1
+  fi
+
+  printf "%s" "$version"
+}
+
+select_asset_name() {
+  local platform="$1"
+  printf "%s-%s.tar.gz" "$BINARY_NAME" "$platform"
+}
+
+extract_binary() {
+  local archive_path="$1"
+  local temp_dir="$2"
+
+  require_command tar
+  tar -xzf "$archive_path" -C "$temp_dir"
+
+  if [ ! -f "$temp_dir/$BINARY_NAME" ]; then
+    log_error "File '$BINARY_NAME' not found after extraction"
+    exit 1
+  fi
+
+  chmod +x "$temp_dir/$BINARY_NAME"
+}
+
+resolve_install_dir() {
+  if [ -w "$DEFAULT_INSTALL_DIR" ]; then
+    printf "%s" "$DEFAULT_INSTALL_DIR"
+    return
+  fi
+
+  if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+    printf "%s" "$DEFAULT_INSTALL_DIR"
+    return
+  fi
+
+  mkdir -p "$FALLBACK_INSTALL_DIR"
+  printf "%s" "$FALLBACK_INSTALL_DIR"
+}
+
+install_binary() {
+  local source_binary="$1"
+  local install_dir="$2"
+  local target="$install_dir/$BINARY_NAME"
+
+  log_info "Installing to ${target}"
+
+  if [ "$install_dir" = "$DEFAULT_INSTALL_DIR" ] && [ ! -w "$install_dir" ]; then
+    if command -v sudo >/dev/null 2>&1; then
+      sudo install -m 755 "$source_binary" "$target"
+    else
+      log_error "No write access to ${install_dir} and sudo is unavailable"
+      exit 1
+    fi
+  else
+    install -m 755 "$source_binary" "$target"
+  fi
+}
+
+check_dependencies() {
+  local platform_os="$1"
+  local missing=()
+
+  if ! command -v yt-dlp >/dev/null 2>&1 && ! command -v youtube-dl >/dev/null 2>&1; then
+    missing+=("yt-dlp")
+  fi
+
+  if ! command -v ffmpeg >/dev/null 2>&1; then
+    missing+=("ffmpeg")
+  fi
+
+  if [ "${#missing[@]}" -eq 0 ]; then
+    log_info "Optional dependencies detected (yt-dlp/ffmpeg)."
+    return
+  fi
+
+  log_warn "Missing dependencies: ${missing[*]}"
+  if [ "$platform_os" = "macos" ]; then
+    log_info "Install with Homebrew: brew install ffmpeg yt-dlp"
+  else
+    log_info "Install with apt: sudo apt install ffmpeg"
+    log_info "Install yt-dlp: python3 -m pip install -U yt-dlp"
+  fi
+}
+
+print_path_hint() {
+  local install_dir="$1"
+  case ":$PATH:" in
+    *":${install_dir}:"*) ;;
+    *)
+      log_warn "${install_dir} is not in PATH for this session."
+      log_info "Add to your shell profile: export PATH=\"${install_dir}:\$PATH\""
+      ;;
+  esac
+}
+
+main() {
+  printf "\nCutube CLI Installer\n\n"
+
+  local platform version asset_name asset_url temp_dir archive_path install_dir
+  platform="$(detect_platform)"
+  log_info "Detected platform: ${platform}"
+
+  version="$(get_latest_version)"
+  log_info "Latest version: ${version}"
+
+  asset_name="$(select_asset_name "$platform")"
+  asset_url="https://github.com/${REPO}/releases/download/${version}/${asset_name}"
+
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' EXIT
+
+  archive_path="${temp_dir}/${asset_name}"
+
+  log_info "Downloading ${asset_name}"
+  download_file "$asset_url" "$archive_path"
+
+  extract_binary "$archive_path" "$temp_dir"
+
+  install_dir="$(resolve_install_dir)"
+  install_binary "${temp_dir}/${BINARY_NAME}" "$install_dir"
+
+  print_path_hint "$install_dir"
+  check_dependencies "${platform%%-*}"
+
+  if command -v "$BINARY_NAME" >/dev/null 2>&1; then
+    log_info "Installation completed. Installed version:"
+    "$BINARY_NAME" --version || true
+  else
+    log_info "Installation completed at ${install_dir}/${BINARY_NAME}"
+  fi
+
+  printf "\nUse: cutube --help\n"
+}
+
+main "$@"

--- a/tests/Cutube.Api.Tests/Unit/Services/DownloadQueueTests.cs
+++ b/tests/Cutube.Api.Tests/Unit/Services/DownloadQueueTests.cs
@@ -144,7 +144,7 @@ public class DownloadQueueTests
         var items = queue.DequeueAllAsync(cts.Token);
 
         // Should throw OperationCanceledException when cancelled
-        var exception = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
         {
             await foreach (var _ in items)
             {


### PR DESCRIPTION
## Summary
This branch introduces a complete cross-platform installer flow for the Cutube CLI, including bash and PowerShell installers, published install documentation, and automated GitHub Pages deployment.
The goal is to provide a one-command install path for Linux, macOS, and Windows while keeping fallback download options documented.

## Key Changes
- Added GitHub Pages deployment workflow for installer/docs assets (`.github/workflows/deploy-pages.yml`)
- Added installer landing page and full installation guide (`docs/index.html`, `docs/installation.md`)
- Added cross-platform install scripts for Unix and Windows (`scripts/install.sh`, `scripts/install.ps1`)
- Linked installer entry points from project docs (`README.md`)

## Quality
Tests passing: 166 tests
Skipped: 1 test (`DirectoryWithoutWritePermission_ReturnsFailure`) due to OS permission requirement, explicitly tagged `RequiresRoot`
Build: succeeds with existing warnings unrelated to this branch (`NU1510`, `ASPDEPR002`)

## Notes
- No breaking runtime/API changes introduced
- Installer scripts resolve latest GitHub release and install the platform-specific binary
- Pages deploy is triggered by changes in docs/installer scripts on `main` and `develop`