### PR TITLE
feat(docker): add root compose orchestration (Cutube-ogg)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,18 @@
-# RabbitMQ Configuration
+# Cutube Environment Configuration
+
+# RabbitMQ
 RABBITMQ_USER=cutube
-RABBITMQ_PASS=cutube123
+RABBITMQ_PASS=your-secure-password-here
+
+# API
+ASPNETCORE_ENVIRONMENT=Production
+
+# Worker
+DOTNET_ENVIRONMENT=Production
+WORKER_REPLICAS=2
+MAX_CONCURRENT=3
+
+# Web
+NODE_ENV=production
+NEXT_PUBLIC_API_URL=http://localhost:5000
+NEXT_PUBLIC_SIGNALR_URL=http://localhost:5000/hub

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  api:
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      Logging__LogLevel__Default: Debug
+
+  worker:
+    environment:
+      DOTNET_ENVIRONMENT: Development
+      Logging__LogLevel__Default: Debug
+    deploy:
+      replicas: 1
+
+  web:
+    environment:
+      NODE_ENV: development
+      NEXT_PUBLIC_API_URL: http://localhost:5000
+      NEXT_PUBLIC_SIGNALR_URL: http://localhost:5000/hub
+    volumes:
+      - ./cutube-web:/app:cached
+      - /app/node_modules
+    command: npm run dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,29 +2,121 @@ version: '3.8'
 
 services:
   rabbitmq:
-    image: rabbitmq:4-management
+    image: rabbitmq:4-management-alpine
     container_name: cutube-rabbitmq
     hostname: rabbitmq
     ports:
-      - "5672:5672"   # AMQP protocol
-      - "15672:15672" # Management UI
+      - "5672:5672"
+      - "15672:15672"
     environment:
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-cutube}
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS:-cutube123}
       RABBITMQ_DEFAULT_VHOST: "/"
     volumes:
-      - rabbitmq_data:/var/lib/rabbitmq
-      - ./docker/rabbitmq/enabled_plugins:/etc/rabbitmq/enabled_plugins
+      - rabbitmq-data:/var/lib/rabbitmq
     healthcheck:
-      test: ["CMD", "rabbitmq-diagnostics", "check_running"]
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
       interval: 30s
       timeout: 10s
       retries: 3
+      start_period: 10s
     networks:
       - cutube-network
+    restart: unless-stopped
+
+  api:
+    build:
+      context: .
+      dockerfile: src/Cutube.Api/Dockerfile
+    container_name: cutube-api
+    ports:
+      - "5000:8080"
+      - "5001:8081"
+    environment:
+      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT:-Production}
+      ASPNETCORE_URLS: http://+:8080
+      RabbitMq__Host: rabbitmq
+      RabbitMq__Port: 5672
+      RabbitMq__UserName: ${RABBITMQ_USER:-cutube}
+      RabbitMq__Password: ${RABBITMQ_PASS:-cutube123}
+      RabbitMq__VirtualHost: "/"
+      SignalR__Enabled: "true"
+      Logging__LogLevel__Default: Information
+      Logging__LogLevel__Microsoft_AspNetCore: Warning
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    volumes:
+      - downloads-data:/app/downloads
+      - ./logs/api:/app/logs
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    networks:
+      - cutube-network
+    restart: unless-stopped
+
+  worker:
+    build:
+      context: .
+      dockerfile: src/Cutube.Worker/Dockerfile
+    container_name: cutube-worker
+    environment:
+      DOTNET_ENVIRONMENT: ${DOTNET_ENVIRONMENT:-Production}
+      RabbitMq__Host: rabbitmq
+      RabbitMq__Port: 5672
+      RabbitMq__UserName: ${RABBITMQ_USER:-cutube}
+      RabbitMq__Password: ${RABBITMQ_PASS:-cutube123}
+      RabbitMq__VirtualHost: "/"
+      Worker__MaxConcurrentDownloads: ${MAX_CONCURRENT:-3}
+      Worker__ApiBaseUrl: http://api:8080
+      Logging__LogLevel__Default: Information
+      Logging__LogLevel__Cutube: Debug
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      api:
+        condition: service_healthy
+    volumes:
+      - downloads-data:/downloads
+      - ./logs/worker:/app/logs
+    networks:
+      - cutube-network
+    restart: unless-stopped
+    deploy:
+      replicas: ${WORKER_REPLICAS:-2}
+
+  web:
+    build:
+      context: ./cutube-web
+      dockerfile: Dockerfile
+    container_name: cutube-web
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: ${NODE_ENV:-production}
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:5000}
+      NEXT_PUBLIC_SIGNALR_URL: ${NEXT_PUBLIC_SIGNALR_URL:-http://localhost:5000/hub}
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    networks:
+      - cutube-network
+    restart: unless-stopped
 
 volumes:
-  rabbitmq_data:
+  rabbitmq-data:
+    driver: local
+  downloads-data:
     driver: local
 
 networks:

--- a/scripts/docker-down.sh
+++ b/scripts/docker-down.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE_CMD="docker compose"
+else
+  COMPOSE_CMD="docker-compose"
+fi
+
+echo "Stopping Cutube stack..."
+$COMPOSE_CMD down
+echo "Done."

--- a/scripts/docker-up.sh
+++ b/scripts/docker-up.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${GREEN}Starting Cutube stack...${NC}"
+
+if [ ! -f .env ]; then
+  echo -e "${YELLOW}Creating .env from .env.example...${NC}"
+  cp .env.example .env
+fi
+
+mkdir -p logs/api logs/worker downloads
+
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE_CMD="docker compose"
+else
+  COMPOSE_CMD="docker-compose"
+fi
+
+echo -e "${GREEN}Pulling images...${NC}"
+$COMPOSE_CMD pull
+
+echo -e "${GREEN}Starting services...${NC}"
+$COMPOSE_CMD up -d
+
+echo
+echo -e "${GREEN}Cutube is running.${NC}"
+echo
+echo "Available URLs:"
+echo "  - Web:           http://localhost:3000"
+echo "  - API:           http://localhost:5000"
+echo "  - RabbitMQ UI:   http://localhost:15672"
+echo

--- a/tests/Cutube.Api.Tests/Unit/Services/DownloadQueueTests.cs
+++ b/tests/Cutube.Api.Tests/Unit/Services/DownloadQueueTests.cs
@@ -144,7 +144,7 @@ public class DownloadQueueTests
         var items = queue.DequeueAllAsync(cts.Token);
 
         // Should throw OperationCanceledException when cancelled
-        var exception = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
         {
             await foreach (var _ in items)
             {


### PR DESCRIPTION
## Summary
This branch adds a root-level Docker Compose stack to orchestrate RabbitMQ, API, worker, and web services in one command.
It also includes helper scripts and environment defaults to make local bring-up reproducible and faster.
The test fix commit resolves the prior flaky cancellation assertion by accepting the runtime-specific cancellation exception type.

## Key Changes
- Added full multi-service root compose orchestration with health checks and shared volumes (`docker-compose.yml`)
- Added development override for local DX and hot-reload behavior (`docker-compose.override.yml`)
- Added startup/shutdown helper scripts for compose v2/v1 compatibility (`scripts/docker-up.sh`, `scripts/docker-down.sh`)
- Expanded example environment configuration for API/worker/web settings (`.env.example`)
- Fixed queue cancellation test to tolerate TaskCanceledException vs OperationCanceledException variance (`tests/Cutube.Api.Tests/Unit/Services/DownloadQueueTests.cs`)

## Quality
Build: passing with existing repository warnings (no new errors)
Tests passing: 166 passed, 0 failed
Skipped: 1 test (OS permission-dependent root-required scenario; justified)
Review blockers from previous run: resolved (cancellation exception mismatch fixed)

## Notes
Compose target branch for this PR is `develop`.
`worker.deploy.replicas` may be ignored outside Swarm and can be tuned later if needed.