### PR TITLE
fix(compose): stabilize worker startup and RabbitMQ wiring (Cutube-6xb)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,4 +15,4 @@ MAX_CONCURRENT=3
 # Web
 NODE_ENV=production
 NEXT_PUBLIC_API_URL=http://localhost:5000
-NEXT_PUBLIC_SIGNALR_URL=http://localhost:5000/hub
+NEXT_PUBLIC_SIGNALR_URL=http://localhost:5000/hubs/downloads

--- a/cutube-web/.dockerignore
+++ b/cutube-web/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+.next
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.git
+.gitignore
+.env.local
+.env*
+coverage
+playwright-report
+test-results

--- a/cutube-web/Dockerfile
+++ b/cutube-web/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci
+RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
 
 # Copy source
 COPY . .

--- a/cutube-web/Dockerfile
+++ b/cutube-web/Dockerfile
@@ -30,13 +30,13 @@ COPY --from=build /app/node_modules ./node_modules
 # Environment
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
-ENV PORT=3000
+ENV PORT=4000
 
-EXPOSE 3000
+EXPOSE 4000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD wget -q --spider http://localhost:3000 || exit 1
+    CMD wget -q --spider http://localhost:4000 || exit 1
 
 # Run
 CMD ["npm", "start"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   api:
     environment:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -15,7 +15,7 @@ services:
     environment:
       NODE_ENV: development
       NEXT_PUBLIC_API_URL: http://localhost:5000
-      NEXT_PUBLIC_SIGNALR_URL: http://localhost:5000/hub
+      NEXT_PUBLIC_SIGNALR_URL: http://localhost:5000/hubs/downloads
     volumes:
       - ./cutube-web:/app:cached
       - /app/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,16 +93,16 @@ services:
       dockerfile: Dockerfile
     container_name: cutube-web
     ports:
-      - "3000:3000"
+      - "4000:4000"
     environment:
       NODE_ENV: ${NODE_ENV:-production}
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:5000}
-      NEXT_PUBLIC_SIGNALR_URL: ${NEXT_PUBLIC_SIGNALR_URL:-http://localhost:5000/hub}
+      NEXT_PUBLIC_SIGNALR_URL: ${NEXT_PUBLIC_SIGNALR_URL:-http://localhost:5000/hubs/downloads}
     depends_on:
       api:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:4000"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   rabbitmq:
     image: rabbitmq:4-management-alpine

--- a/scripts/docker-up.sh
+++ b/scripts/docker-up.sh
@@ -30,7 +30,7 @@ echo
 echo -e "${GREEN}Cutube is running.${NC}"
 echo
 echo "Available URLs:"
-echo "  - Web:           http://localhost:3000"
+echo "  - Web:           http://localhost:4000"
 echo "  - API:           http://localhost:5000"
 echo "  - RabbitMQ UI:   http://localhost:15672"
 echo

--- a/src/Cutube.Api/Dockerfile
+++ b/src/Cutube.Api/Dockerfile
@@ -3,22 +3,31 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy solution and restore
-COPY Cutube.sln ./
+COPY cutube.sln ./
 COPY src/Cutube.Api/Cutube.Api.csproj src/Cutube.Api/
 COPY src/Cutube.Domain/Cutube.Domain.csproj src/Cutube.Domain/
+COPY cutube/cutube.csproj cutube/
 RUN dotnet restore src/Cutube.Api/Cutube.Api.csproj
 
 # Copy source and build
 COPY src/Cutube.Api/ src/Cutube.Api/
 COPY src/Cutube.Domain/ src/Cutube.Domain/
-RUN dotnet publish src/Cutube.Api/Cutube.Api.csproj -c Release -o /app/publish --no-restore
+COPY cutube/ cutube/
+RUN dotnet publish src/Cutube.Api/Cutube.Api.csproj -c Release -o /app/publish
 
 # Runtime stage
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS runtime
 WORKDIR /app
 
-# Install curl for healthcheck
-RUN apk add --no-cache curl
+# Install runtime dependencies
+RUN apk add --no-cache \
+    curl \
+    ffmpeg \
+    python3 \
+    py3-pip
+
+# Install yt-dlp
+RUN pip3 install --no-cache-dir --break-system-packages yt-dlp
 
 # Copy published app
 COPY --from=build /app/publish .

--- a/src/Cutube.Api/Program.cs
+++ b/src/Cutube.Api/Program.cs
@@ -8,6 +8,7 @@ using Cutube.Domain.Interfaces;
 using Cutube.Domain.Services;
 using Cutube.Infrastructure;
 using MassTransit;
+using Microsoft.Extensions.Options;
 
 // Program.cs is excluded from code coverage via GlobalSuppressions.cs or project configuration
 var builder = WebApplication.CreateBuilder(args);
@@ -90,7 +91,7 @@ if (!builder.Environment.IsEnvironment("Testing"))
     {
         x.UsingRabbitMq((context, cfg) =>
         {
-            var options = context.GetRequiredService<RabbitMqOptions>();
+            var options = context.GetRequiredService<IOptions<RabbitMqOptions>>().Value;
 
             cfg.Host($"rabbitmq://{options.UserName}:{options.Password}@{options.Host}:{options.Port}{options.VirtualHost}");
 

--- a/src/Cutube.Api/Program.cs
+++ b/src/Cutube.Api/Program.cs
@@ -74,7 +74,7 @@ builder.Services.AddSingleton<IVideoMetadataProvider, YtDlpMetadataProvider>();
  // API Services
  builder.Services.AddSingleton<IDownloadQueue, DownloadQueue>();
  builder.Services.AddSingleton<IDownloadStatusRepository, InMemoryStatusRepository>();
- builder.Services.AddSingleton<DlqService>();
+ builder.Services.AddScoped<DlqService>();
  builder.Services.AddSingleton<ConnectionTracker>();
  builder.Services.AddHostedService<BackgroundDownloadWorker>();
  builder.Services.AddHostedService<DownloadStatusCleanupService>();
@@ -106,7 +106,7 @@ if (!builder.Environment.IsEnvironment("Testing"))
     });
 
     // Registrar producer
-    builder.Services.AddSingleton<IQueueProducer, RabbitMqProducer>();
+    builder.Services.AddScoped<IQueueProducer, RabbitMqProducer>();
 }
 
 // Configure options

--- a/src/Cutube.Api/Queuing/RabbitMqProducer.cs
+++ b/src/Cutube.Api/Queuing/RabbitMqProducer.cs
@@ -12,9 +12,7 @@ namespace Cutube.Api.Queuing;
 /// </summary>
 public class RabbitMqProducer : IQueueProducer
 {
-    private const string DownloadsQueue = "cutube.downloads";
-
-    private readonly IBus _bus;
+    private readonly IPublishEndpoint _publishEndpoint;
     private readonly RabbitMqOptions _options;
     private readonly ILogger<RabbitMqProducer> _logger;
     private readonly SemaphoreSlim _connectionLock = new(1, 1);
@@ -23,11 +21,11 @@ public class RabbitMqProducer : IQueueProducer
     public bool IsConnected => _isConnected;
 
     public RabbitMqProducer(
-        IBus bus,
+        IPublishEndpoint publishEndpoint,
         IOptions<RabbitMqOptions> options,
         ILogger<RabbitMqProducer> logger)
     {
-        _bus = bus;
+        _publishEndpoint = publishEndpoint;
         _options = options.Value;
         _logger = logger;
         _isConnected = true; // MassTransit gerencia reconexão automaticamente
@@ -53,10 +51,8 @@ public class RabbitMqProducer : IQueueProducer
                 message.CorrelationId,
                 message.Url);
 
-            // Publicar mensagem usando MassTransit
-            var endpoint = await _bus.GetSendEndpoint(new Uri($"queue:{DownloadsQueue}"));
-
-            await endpoint.Send(message, cancellationToken);
+            // Publicar mensagem usando exchange de mensagem (evita conflito de declaração de fila)
+            await _publishEndpoint.Publish(message, cancellationToken);
 
             _isConnected = true;
             _logger.LogInformation(

--- a/src/Cutube.Worker/Dockerfile
+++ b/src/Cutube.Worker/Dockerfile
@@ -3,18 +3,22 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy solution and restore
-COPY Cutube.sln ./
+COPY cutube.sln ./
 COPY src/Cutube.Worker/Cutube.Worker.csproj src/Cutube.Worker/
+COPY src/Cutube.Api/Cutube.Api.csproj src/Cutube.Api/
 COPY src/Cutube.Domain/Cutube.Domain.csproj src/Cutube.Domain/
+COPY cutube/cutube.csproj cutube/
 RUN dotnet restore src/Cutube.Worker/Cutube.Worker.csproj
 
 # Copy source and build
 COPY src/Cutube.Worker/ src/Cutube.Worker/
+COPY src/Cutube.Api/ src/Cutube.Api/
 COPY src/Cutube.Domain/ src/Cutube.Domain/
-RUN dotnet publish src/Cutube.Worker/Cutube.Worker.csproj -c Release -o /app/publish --no-restore
+COPY cutube/ cutube/
+RUN dotnet publish src/Cutube.Worker/Cutube.Worker.csproj -c Release -o /app/publish -p:ErrorOnDuplicatePublishOutputFiles=false
 
 # Runtime stage
-FROM mcr.microsoft.com/dotnet/runtime:10.0-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS runtime
 WORKDIR /app
 
 # Install dependencies
@@ -25,7 +29,7 @@ RUN apk add --no-cache \
     curl
 
 # Install yt-dlp
-RUN pip3 install --no-cache-dir yt-dlp
+RUN pip3 install --no-cache-dir --break-system-packages yt-dlp
 
 # Copy published app
 COPY --from=build /app/publish .

--- a/src/Cutube.Worker/Program.cs
+++ b/src/Cutube.Worker/Program.cs
@@ -7,6 +7,7 @@ using Polly;
 using Polly.Extensions.Http;
 using Serilog;
 using Cutube.Api.Queuing.Messages;
+using Microsoft.Extensions.Options;
 
 IHost host = Host.CreateDefaultBuilder(args)
     .UseSerilog((context, services, loggerConfiguration) =>
@@ -25,6 +26,10 @@ IHost host = Host.CreateDefaultBuilder(args)
 
         services.Configure<RetryPolicyOptions>(
             context.Configuration.GetSection(RetryPolicyOptions.SectionName)
+        );
+
+        services.Configure<RabbitMqOptions>(
+            context.Configuration.GetSection(RabbitMqOptions.SectionName)
         );
 
         // HttpClient for API communication
@@ -51,7 +56,7 @@ IHost host = Host.CreateDefaultBuilder(args)
 
             x.UsingRabbitMq((context, cfg) =>
             {
-                var rabbitMqConfig = context.GetRequiredService<RabbitMqOptions>();
+                var rabbitMqConfig = context.GetRequiredService<IOptions<RabbitMqOptions>>().Value;
 
                 cfg.Host($"amqp://{rabbitMqConfig.UserName}:{rabbitMqConfig.Password}@{rabbitMqConfig.Host}:{rabbitMqConfig.Port}{rabbitMqConfig.VirtualHost}");
 


### PR DESCRIPTION
## Summary
This branch fixes local stack startup failures caused by mismatched container configuration across API, Worker, and Web services. It also aligns RabbitMQ publishing behavior to avoid queue declaration conflicts and ensure messages flow consistently between API and Worker.

## Key Changes
- Fixed Docker build/runtime dependencies for API and Worker images, including required project copies and yt-dlp install flags (`src/Cutube.Api/Dockerfile`, `src/Cutube.Worker/Dockerfile`)
- Standardized Web service runtime to port 4000 and updated compose/env references to the current SignalR hub route (`docker-compose.yml`, `docker-compose.override.yml`, `.env.example`, `scripts/docker-up.sh`, `cutube-web/Dockerfile`)
- Switched API producer publishing to `IPublishEndpoint` and adjusted DI/options resolution for MassTransit and RabbitMQ settings (`src/Cutube.Api/Queuing/RabbitMqProducer.cs`, `src/Cutube.Api/Program.cs`, `src/Cutube.Worker/Program.cs`)
- Added `cutube-web/.dockerignore` to reduce Docker build context and avoid noisy artifacts in image builds (`cutube-web/.dockerignore`)

## Quality
Tests passing: 166 tests (`dotnet test`)
Skipped: 1 test - `DirectoryWithoutWritePermission_ReturnsFailure` (`tests/Cutube.Domain.Tests/Services/ValidationServiceTests.cs:228`), justified because it requires special OS/root permission behavior not reliable in CI.
No blocking issues found in review against base branch.

## Notes
No breaking API contract changes are introduced.
Operational change: Web UI is now exposed on `http://localhost:4000` in docker-compose.