### PR TITLE
feat(worker): improve robustness and observability (Cutube-vmv.3)

### DIFF
--- a/src/Cutube.Worker/Configuration/HttpRetryPolicyFactory.cs
+++ b/src/Cutube.Worker/Configuration/HttpRetryPolicyFactory.cs
@@ -6,20 +6,49 @@ namespace Cutube.Worker.Configuration;
 
 public static class HttpRetryPolicyFactory
 {
-    public static IAsyncPolicy<HttpResponseMessage> Create(Action<string>? onRetryLog = null)
+    public static IAsyncPolicy<HttpResponseMessage> CreateRetryPolicy(
+        NotificationResilienceOptions options,
+        Action<string>? onRetryLog = null)
     {
+        var retryCount = Math.Max(0, options.MaxRetries);
+        var initialDelaySeconds = Math.Max(1, options.InitialRetryDelaySeconds);
+
         return HttpPolicyExtensions
             .HandleTransientHttpError()
             .OrResult(ShouldRetry)
             .WaitAndRetryAsync(
-                retryCount: 3,
-                sleepDurationProvider: retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
+                retryCount: retryCount,
+                sleepDurationProvider: retryAttempt =>
+                    TimeSpan.FromSeconds(initialDelaySeconds * Math.Pow(2, retryAttempt - 1)),
                 onRetry: (outcome, timespan, retryAttempt, context) =>
                 {
                     var statusCode = outcome.Result?.StatusCode;
                     var reason = outcome.Exception?.Message ?? outcome.Result?.ReasonPhrase ?? "Unknown reason";
                     onRetryLog?.Invoke($"Retry {retryAttempt} after {timespan.TotalSeconds}s due to status {(int?)statusCode ?? 0} - {reason}");
                 });
+    }
+
+    public static IAsyncPolicy<HttpResponseMessage> CreateCircuitBreakerPolicy(
+        NotificationResilienceOptions options,
+        Action<string>? onCircuitLog = null)
+    {
+        var consecutiveFailures = Math.Max(1, options.ConsecutiveFailuresBeforeBreak);
+        var breakSeconds = Math.Max(1, options.CircuitBreakSeconds);
+
+        return HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .OrResult(ShouldRetry)
+            .CircuitBreakerAsync(
+                handledEventsAllowedBeforeBreaking: consecutiveFailures,
+                durationOfBreak: TimeSpan.FromSeconds(breakSeconds),
+                onBreak: (outcome, timespan) =>
+                {
+                    var statusCode = outcome.Result?.StatusCode;
+                    var reason = outcome.Exception?.Message ?? outcome.Result?.ReasonPhrase ?? "Unknown reason";
+                    onCircuitLog?.Invoke($"Circuit opened for {timespan.TotalSeconds}s due to status {(int?)statusCode ?? 0} - {reason}");
+                },
+                onReset: () => onCircuitLog?.Invoke("Circuit reset"),
+                onHalfOpen: () => onCircuitLog?.Invoke("Circuit half-open: next request is a trial"));
     }
 
     public static bool ShouldRetry(HttpResponseMessage response)

--- a/src/Cutube.Worker/Configuration/NotificationResilienceOptions.cs
+++ b/src/Cutube.Worker/Configuration/NotificationResilienceOptions.cs
@@ -1,0 +1,14 @@
+namespace Cutube.Worker.Configuration;
+
+public class NotificationResilienceOptions
+{
+    public const string SectionName = "NotificationResilience";
+
+    public int MaxRetries { get; set; } = 3;
+
+    public int InitialRetryDelaySeconds { get; set; } = 2;
+
+    public int ConsecutiveFailuresBeforeBreak { get; set; } = 5;
+
+    public int CircuitBreakSeconds { get; set; } = 30;
+}

--- a/src/Cutube.Worker/Consumers/DownloadConsumer.cs
+++ b/src/Cutube.Worker/Consumers/DownloadConsumer.cs
@@ -6,6 +6,7 @@ using Cutube.Worker.Services;
 using MassTransit;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using SerilogLogContext = Serilog.Context.LogContext;
 
 namespace Cutube.Worker.Consumers;
 
@@ -38,6 +39,9 @@ public class DownloadConsumer : IConsumer<DownloadMessage>
     {
         var message = context.Message;
         var correlationId = message.CorrelationId;
+        using var correlationScope = SerilogLogContext.PushProperty("CorrelationId", correlationId);
+        using var messageScope = SerilogLogContext.PushProperty("MessageId", message.MessageId);
+        var startedAt = DateTime.UtcNow;
 
         _logger.LogInformation(
             "Processing download: {CorrelationId}, URL: {Url}, Attempt: {RetryCount}",
@@ -60,6 +64,10 @@ public class DownloadConsumer : IConsumer<DownloadMessage>
             _logger.LogInformation(
                 "Download completed successfully: {CorrelationId}",
                 correlationId);
+
+            _logger.LogInformation(
+                "Download pipeline duration: {ElapsedMs}ms",
+                (DateTime.UtcNow - startedAt).TotalMilliseconds);
         }
         catch (TransientException ex)
         {

--- a/src/Cutube.Worker/Cutube.Worker.csproj
+++ b/src/Cutube.Worker/Cutube.Worker.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>
 

--- a/src/Cutube.Worker/Dockerfile
+++ b/src/Cutube.Worker/Dockerfile
@@ -40,7 +40,7 @@ RUN mkdir -p /downloads
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD pgrep -x "dotnet" > /dev/null || exit 1
+    CMD [ -f /tmp/cutube-worker-health ] && [ "$(cat /tmp/cutube-worker-health)" = "healthy" ] || exit 1
 
 # Run
 ENTRYPOINT ["dotnet", "Cutube.Worker.dll"]

--- a/src/Cutube.Worker/Health/RabbitMqConnectionHealthCheck.cs
+++ b/src/Cutube.Worker/Health/RabbitMqConnectionHealthCheck.cs
@@ -1,0 +1,44 @@
+using Cutube.Contracts.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using System.Net.Sockets;
+
+namespace Cutube.Worker.Health;
+
+public class RabbitMqConnectionHealthCheck : IHealthCheck
+{
+    private readonly RabbitMqOptions _rabbitMqOptions;
+
+    public RabbitMqConnectionHealthCheck(IOptions<RabbitMqOptions> rabbitMqOptions)
+    {
+        _rabbitMqOptions = rabbitMqOptions.Value;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        using var tcpClient = new TcpClient();
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(Math.Max(1, _rabbitMqOptions.Timeout)));
+
+        try
+        {
+            await tcpClient.ConnectAsync(_rabbitMqOptions.Host, _rabbitMqOptions.Port, timeoutCts.Token);
+
+            return HealthCheckResult.Healthy(
+                $"RabbitMQ reachable at {_rabbitMqOptions.Host}:{_rabbitMqOptions.Port}");
+        }
+        catch (OperationCanceledException)
+        {
+            return HealthCheckResult.Unhealthy(
+                $"Timed out connecting to RabbitMQ at {_rabbitMqOptions.Host}:{_rabbitMqOptions.Port}");
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy(
+                $"Failed to connect to RabbitMQ at {_rabbitMqOptions.Host}:{_rabbitMqOptions.Port}",
+                ex);
+        }
+    }
+}

--- a/src/Cutube.Worker/Program.cs
+++ b/src/Cutube.Worker/Program.cs
@@ -1,5 +1,6 @@
 using Cutube.Worker.Configuration;
 using Cutube.Worker.Consumers;
+using Cutube.Worker.Health;
 using Cutube.Worker.Handlers;
 using Cutube.Worker.Services;
 using Cutube.Contracts.Configuration;
@@ -30,6 +31,14 @@ IHost host = Host.CreateDefaultBuilder(args)
             context.Configuration.GetSection(RabbitMqOptions.SectionName)
         );
 
+        services.Configure<NotificationResilienceOptions>(
+            context.Configuration.GetSection(NotificationResilienceOptions.SectionName)
+        );
+
+        var notificationResilience = context.Configuration
+            .GetSection(NotificationResilienceOptions.SectionName)
+            .Get<NotificationResilienceOptions>() ?? new NotificationResilienceOptions();
+
         // HttpClient for API communication
         services.AddHttpClient<IDownloadStatusNotificationService, DownloadStatusNotificationService>(client =>
         {
@@ -37,7 +46,11 @@ IHost host = Host.CreateDefaultBuilder(args)
             client.BaseAddress = new Uri(apiBaseUrl);
             client.Timeout = TimeSpan.FromSeconds(30);
         })
-        .AddPolicyHandler(HttpRetryPolicyFactory.Create(Console.WriteLine));
+        .AddPolicyHandler(HttpRetryPolicyFactory.CreateCircuitBreakerPolicy(notificationResilience, Console.WriteLine))
+        .AddPolicyHandler(HttpRetryPolicyFactory.CreateRetryPolicy(notificationResilience, Console.WriteLine));
+
+        services.AddHealthChecks()
+            .AddCheck<RabbitMqConnectionHealthCheck>("rabbitmq_connection");
 
         // Domain services
         services.AddSingleton<IDownloadProcessingService, DownloadProcessingService>();
@@ -78,6 +91,7 @@ IHost host = Host.CreateDefaultBuilder(args)
 
         // Worker service
         services.AddHostedService<Cutube.Worker.Worker>();
+        services.AddHostedService<WorkerHealthReporterService>();
     })
     .Build();
 

--- a/src/Cutube.Worker/Services/DownloadProcessingService.cs
+++ b/src/Cutube.Worker/Services/DownloadProcessingService.cs
@@ -2,6 +2,7 @@ using Cutube.Contracts.Messages;
 using Cutube.Worker.Configuration;
 using Cutube.Worker.Services.Models;
 using Microsoft.Extensions.Options;
+using Serilog.Context;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text.RegularExpressions;
@@ -30,6 +31,10 @@ public partial class DownloadProcessingService : IDownloadProcessingService
     public async Task ProcessDownloadAsync(DownloadMessage message, CancellationToken cancellationToken = default)
     {
         var correlationId = message.CorrelationId;
+        using var correlationScope = LogContext.PushProperty("CorrelationId", correlationId);
+        using var messageScope = LogContext.PushProperty("MessageId", message.MessageId);
+        var totalStopwatch = Stopwatch.StartNew();
+        var notifyStopwatch = Stopwatch.StartNew();
 
         _logger.LogInformation("Starting download: {CorrelationId}, URL: {Url}", correlationId, message.Url);
 
@@ -37,6 +42,8 @@ public partial class DownloadProcessingService : IDownloadProcessingService
         {
             // Notify processing start
             await _notificationService.NotifyStatusAsync(correlationId, "processing", cancellationToken);
+            notifyStopwatch.Stop();
+            _logger.LogDebug("Processing notification sent in {ElapsedMs}ms", notifyStopwatch.ElapsedMilliseconds);
 
             // Create output directory if it doesn't exist
             var outputDirectory = Path.GetDirectoryName(message.OutputPath);
@@ -57,11 +64,14 @@ public partial class DownloadProcessingService : IDownloadProcessingService
                 correlationId,
                 cancellationToken);
 
+            _logger.LogDebug("yt-dlp execution finished with exit code {ExitCode}", exitCode);
+
             if (exitCode == 0)
             {
                 // Success
                 await _notificationService.NotifyStatusAsync(correlationId, "completed", cancellationToken);
                 _logger.LogInformation("Download completed: {CorrelationId}", correlationId);
+                _logger.LogInformation("Total processing duration: {ElapsedMs}ms", totalStopwatch.ElapsedMilliseconds);
             }
             else if (exitCode == 1 && cancellationToken.IsCancellationRequested)
             {
@@ -96,6 +106,7 @@ public partial class DownloadProcessingService : IDownloadProcessingService
                 ex.Message);
 
             _logger.LogError(ex, "Download failed: {CorrelationId}", correlationId);
+            _logger.LogInformation("Total processing duration: {ElapsedMs}ms", totalStopwatch.ElapsedMilliseconds);
             throw;
         }
     }

--- a/src/Cutube.Worker/Services/DownloadStatusNotificationService.cs
+++ b/src/Cutube.Worker/Services/DownloadStatusNotificationService.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using Polly.CircuitBreaker;
 
 namespace Cutube.Worker.Services;
 
@@ -8,6 +9,12 @@ namespace Cutube.Worker.Services;
 /// </summary>
 public class DownloadStatusNotificationService : IDownloadStatusNotificationService
 {
+    private static readonly System.Diagnostics.Metrics.Meter Meter = new("Cutube.Worker.Notifications", "1.0.0");
+    private static readonly System.Diagnostics.Metrics.Counter<long> SuccessCounter =
+        Meter.CreateCounter<long>("cutube.worker.notifications.success");
+    private static readonly System.Diagnostics.Metrics.Counter<long> FailureCounter =
+        Meter.CreateCounter<long>("cutube.worker.notifications.failure");
+
     private readonly HttpClient _httpClient;
     private readonly ILogger<DownloadStatusNotificationService> _logger;
 
@@ -33,37 +40,7 @@ public class DownloadStatusNotificationService : IDownloadStatusNotificationServ
             errorMessage = errorMessage
         };
 
-        try
-        {
-            var content = new StringContent(
-                JsonSerializer.Serialize(payload),
-                Encoding.UTF8,
-                "application/json");
-
-            var response = await _httpClient.PatchAsync(url, content, cancellationToken);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogWarning(
-                    "Failed to notify status: {CorrelationId}, Status: {StatusCode}",
-                    correlationId,
-                    response.StatusCode);
-            }
-            else
-            {
-                _logger.LogDebug(
-                    "Status notified: {CorrelationId}, Status: {Status}",
-                    correlationId,
-                    status);
-            }
-        }
-        catch (Exception ex)
-        {
-            // Don't throw - notification failure should not break download
-            _logger.LogError(ex,
-                "Error notifying status: {CorrelationId}",
-                correlationId);
-        }
+        await SendAsync(correlationId, "status", url, HttpMethod.Patch, payload, cancellationToken);
     }
 
     public async Task NotifyProgressAsync(
@@ -86,30 +63,7 @@ public class DownloadStatusNotificationService : IDownloadStatusNotificationServ
             eta
         };
 
-        try
-        {
-            var content = new StringContent(
-                JsonSerializer.Serialize(payload),
-                Encoding.UTF8,
-                "application/json");
-
-            var response = await _httpClient.PostAsync(url, content, cancellationToken);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogDebug(
-                    "Failed to notify progress: {CorrelationId}, StatusCode: {StatusCode}",
-                    correlationId,
-                    response.StatusCode);
-            }
-        }
-        catch (Exception ex)
-        {
-            // Don't throw - notification failure should not break download
-            _logger.LogDebug(ex,
-                "Error notifying progress: {CorrelationId}",
-                correlationId);
-        }
+        await SendAsync(correlationId, "progress", url, HttpMethod.Post, payload, cancellationToken);
     }
 
     public async Task NotifyDeadLetterAsync(
@@ -127,6 +81,23 @@ public class DownloadStatusNotificationService : IDownloadStatusNotificationServ
             retryCount
         };
 
+        await SendAsync(correlationId, "deadletter", url, HttpMethod.Patch, payload, cancellationToken);
+    }
+
+    private async Task SendAsync(
+        string correlationId,
+        string notificationType,
+        string url,
+        HttpMethod method,
+        object payload,
+        CancellationToken cancellationToken)
+    {
+        using var scope = _logger.BeginScope(new Dictionary<string, object>
+        {
+            ["CorrelationId"] = correlationId,
+            ["NotificationType"] = notificationType
+        });
+
         try
         {
             var content = new StringContent(
@@ -134,29 +105,37 @@ public class DownloadStatusNotificationService : IDownloadStatusNotificationServ
                 Encoding.UTF8,
                 "application/json");
 
-            var response = await _httpClient.PatchAsync(url, content, cancellationToken);
+            using var request = new HttpRequestMessage(method, url) { Content = content };
+            using var response = await _httpClient.SendAsync(request, cancellationToken);
 
-            if (!response.IsSuccessStatusCode)
+            if (response.IsSuccessStatusCode)
+            {
+                SuccessCounter.Add(1);
+                _logger.LogDebug("Notification sent successfully with status code {StatusCode}", response.StatusCode);
+                return;
+            }
+
+            FailureCounter.Add(1);
+
+            if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
             {
                 _logger.LogWarning(
-                    "Failed to notify dead letter status: {CorrelationId}, Status: {StatusCode}",
-                    correlationId,
+                    "Permanent notification failure (no retry). Status code: {StatusCode}",
                     response.StatusCode);
+                return;
             }
-            else
-            {
-                _logger.LogInformation(
-                    "Dead letter status notified: {CorrelationId}, RetryCount: {RetryCount}",
-                    correlationId,
-                    retryCount);
-            }
+
+            _logger.LogError("Notification failed after retry policy. Status code: {StatusCode}", response.StatusCode);
+        }
+        catch (BrokenCircuitException ex)
+        {
+            FailureCounter.Add(1);
+            _logger.LogWarning(ex, "Notification skipped because circuit breaker is open");
         }
         catch (Exception ex)
         {
-            // Don't throw - notification failure should not break download
-            _logger.LogError(ex,
-                "Error notifying dead letter status: {CorrelationId}",
-                correlationId);
+            FailureCounter.Add(1);
+            _logger.LogError(ex, "Unexpected error while notifying API");
         }
     }
 }

--- a/src/Cutube.Worker/Services/WorkerHealthReporterService.cs
+++ b/src/Cutube.Worker/Services/WorkerHealthReporterService.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Cutube.Worker.Services;
+
+public class WorkerHealthReporterService : BackgroundService
+{
+    private const string HealthFilePath = "/tmp/cutube-worker-health";
+
+    private readonly HealthCheckService _healthCheckService;
+    private readonly ILogger<WorkerHealthReporterService> _logger;
+
+    public WorkerHealthReporterService(
+        HealthCheckService healthCheckService,
+        ILogger<WorkerHealthReporterService> logger)
+    {
+        _healthCheckService = healthCheckService;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Worker health reporter started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var report = await _healthCheckService.CheckHealthAsync(stoppingToken);
+                var isHealthy = report.Status == HealthStatus.Healthy;
+
+                await File.WriteAllTextAsync(
+                    HealthFilePath,
+                    isHealthy ? "healthy" : "unhealthy",
+                    stoppingToken);
+
+                if (!isHealthy)
+                {
+                    _logger.LogWarning("Worker health is unhealthy: {HealthStatus}", report.Status);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to update worker health file");
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await File.WriteAllTextAsync(HealthFilePath, "unhealthy", cancellationToken);
+        }
+        catch
+        {
+            // Best effort on shutdown.
+        }
+
+        await base.StopAsync(cancellationToken);
+    }
+}

--- a/src/Cutube.Worker/appsettings.json
+++ b/src/Cutube.Worker/appsettings.json
@@ -28,8 +28,14 @@
     "BackoffMultiplier": 6,
     "MaxDelaySeconds": 120
   },
+  "NotificationResilience": {
+    "MaxRetries": 3,
+    "InitialRetryDelaySeconds": 2,
+    "ConsecutiveFailuresBeforeBreak": 5,
+    "CircuitBreakSeconds": 30
+  },
   "Serilog": {
-    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
+    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File", "Serilog.Formatting.Compact" ],
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
@@ -38,8 +44,20 @@
       }
     },
     "WriteTo": [
-      { "Name": "Console", "Args": { "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}" } },
-      { "Name": "File", "Args": { "path": "logs/cutube-worker-.log", "rollingInterval": "Day" } }
+      {
+        "Name": "Console",
+        "Args": {
+          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      },
+      {
+        "Name": "File",
+        "Args": {
+          "path": "logs/cutube-worker-.log",
+          "rollingInterval": "Day",
+          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      }
     ]
   }
 }

--- a/tests/Cutube.Worker.Tests/WorkerRegressionTests.cs
+++ b/tests/Cutube.Worker.Tests/WorkerRegressionTests.cs
@@ -1,9 +1,10 @@
 using System.Net;
-using Cutube.Contracts.Messages;
 using Cutube.Worker.Configuration;
+using Cutube.Contracts.Messages;
 using Cutube.Worker.Consumers;
 using FluentAssertions;
 using MassTransit;
+using Polly.CircuitBreaker;
 
 namespace Cutube.Worker.Tests;
 
@@ -24,6 +25,57 @@ public class WorkerRegressionTests
         var result = HttpRetryPolicyFactory.ShouldRetry(response);
 
         result.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task RetryPolicy_ShouldNotRetryClientErrors()
+    {
+        var options = new NotificationResilienceOptions { MaxRetries = 3 };
+        var attempts = 0;
+        var policy = HttpRetryPolicyFactory.CreateRetryPolicy(options);
+
+        using var response = await policy.ExecuteAsync(() =>
+        {
+            attempts++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        });
+
+        attempts.Should().Be(1);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task RetryPolicy_ShouldRetryServerErrors()
+    {
+        var options = new NotificationResilienceOptions { MaxRetries = 3, InitialRetryDelaySeconds = 1 };
+        var attempts = 0;
+        var policy = HttpRetryPolicyFactory.CreateRetryPolicy(options);
+
+        using var response = await policy.ExecuteAsync(() =>
+        {
+            attempts++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        });
+
+        attempts.Should().Be(4);
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task CircuitBreaker_ShouldOpenAfterConfiguredFailures()
+    {
+        var options = new NotificationResilienceOptions
+        {
+            ConsecutiveFailuresBeforeBreak = 2,
+            CircuitBreakSeconds = 60
+        };
+        var policy = HttpRetryPolicyFactory.CreateCircuitBreakerPolicy(options);
+
+        await policy.ExecuteAsync(() => Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadGateway)));
+        await policy.ExecuteAsync(() => Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadGateway)));
+
+        await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(
+            () => policy.ExecuteAsync(() => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK))));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
This PR hardens worker-to-API notifications and container health reporting to improve resilience during transient failures.
It also adds structured logging and regression coverage so failure behavior is easier to diagnose and safer to operate.

## Key Changes
- Added configurable retry + circuit breaker policies for notification HTTP calls (`src/Cutube.Worker/Configuration/HttpRetryPolicyFactory.cs`)
- Introduced worker health reporting and RabbitMQ connectivity checks used by Docker healthcheck (`src/Cutube.Worker/Services/WorkerHealthReporterService.cs`)
- Refactored notification sending into a single resilient path with metrics and scoped logs (`src/Cutube.Worker/Services/DownloadStatusNotificationService.cs`)
- Added resilience options and compact JSON logging configuration (`src/Cutube.Worker/appsettings.json`)
- Expanded regression tests for retry and circuit-breaker behavior (`tests/Cutube.Worker.Tests/WorkerRegressionTests.cs`)

## Quality
Tests passing: 172 tests
Skipped: 1 test (`DirectoryWithoutWritePermission_ReturnsFailure`) due to OS/root permission dependency
Code review: no blocking issues found

## Notes
No breaking API changes expected.
Operational behavior now depends on `NotificationResilience` settings; defaults are included in worker config.