### PR TITLE
fix(frontend): resolve theme hydration and improve light-mode contrast (Cutube-vmv.4)

### DIFF
--- a/cutube-web/app/globals.css
+++ b/cutube-web/app/globals.css
@@ -69,7 +69,7 @@
   --card-foreground: hsl(220 15% 10%);
 
   /* Primary — Teal */
-  --primary: hsl(172 66% 40%);
+  --primary: hsl(172 70% 28%);
   --primary-foreground: hsl(0 0% 100%);
 
   /* Secondary */
@@ -94,9 +94,9 @@
   --ring: hsl(172 66% 40%);
 
   /* Status colors */
-  --status-downloading: hsl(210 75% 55%);
+  --status-downloading: hsl(210 78% 36%);
   --status-processing: hsl(38 92% 50%);
-  --status-completed: hsl(160 72% 42%);
+  --status-completed: hsl(160 74% 30%);
 }
 
 /* ==========================================================================

--- a/cutube-web/components/theme/theme-toggle.tsx
+++ b/cutube-web/components/theme/theme-toggle.tsx
@@ -7,6 +7,14 @@ import { Button } from "@/components/ui/button";
 export function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
 
+  if (!resolvedTheme) {
+    return (
+      <Button variant="ghost" size="icon" aria-label="Alternar tema" disabled>
+        <span className="h-5 w-5" aria-hidden="true" />
+      </Button>
+    );
+  }
+
   const isDark = resolvedTheme === "dark";
 
   return (


### PR DESCRIPTION
## Summary
This update addresses a theme toggle hydration mismatch that could happen before `resolvedTheme` is available and adjusts key light-mode tokens to improve accessibility contrast. It keeps theme switching behavior intact while making initial render behavior safer and improving readability for primary/status UI states.

## Key Changes
- Added a `resolvedTheme` guard in the theme toggle to render a disabled placeholder until theme resolution is available (`cutube-web/components/theme/theme-toggle.tsx`)
- Preserved toggle semantics and aria labeling for both dark and light mode actions (`cutube-web/components/theme/theme-toggle.tsx`)
- Increased contrast for light-mode `--primary`, `--status-downloading`, and `--status-completed` color tokens (`cutube-web/app/globals.css`)

## Quality
Tests passing: 16 tests (`pnpm run test:e2e`)
Skipped: 0 tests found in project test/spec files
Code review: no blocking issues found

## Notes
- No breaking API changes
- Base branch: `develop`