### PR TITLE
chore: finalize Cutube-vmv.3 quality gates

### DIFF
--- a/cutube/cutube.csproj
+++ b/cutube/cutube.csproj
@@ -14,7 +14,6 @@
       <PackageReference Include="Serilog" Version="4.3.0" />
       <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
       <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-      <PackageReference Include="System.Net.Http.Json" Version="10.0.3" />
       <PackageReference Include="YoutubeDLSharp" Version="1.2.0" />
     </ItemGroup>
 

--- a/src/Cutube.Api/Endpoints/StatusEndpoints.cs
+++ b/src/Cutube.Api/Endpoints/StatusEndpoints.cs
@@ -15,8 +15,7 @@ public static class StatusEndpoints
     public static void MapStatusEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/downloads")
-            .WithTags("Status")
-            .WithOpenApi();
+            .WithTags("Status");
 
         // GET /api/downloads/queue/active - Active downloads (queued + processing)
         group.MapGet("/queue/active", async (
@@ -34,8 +33,7 @@ public static class StatusEndpoints
             });
         })
         .WithName("GetActiveDownloads")
-        .WithSummary("Get active downloads (queued and processing)")
-        .WithOpenApi();
+        .WithSummary("Get active downloads (queued and processing)");
 
         // GET /api/downloads/queue/failed - Failed downloads
         group.MapGet("/queue/failed", async (
@@ -53,8 +51,7 @@ public static class StatusEndpoints
             });
         })
         .WithName("GetFailedDownloads")
-        .WithSummary("Get failed and dead letter downloads")
-        .WithOpenApi();
+        .WithSummary("Get failed and dead letter downloads");
 
          // PATCH /api/downloads/{correlationId}/status - Worker callback
          group.MapPatch("/{correlationId}/status", async (
@@ -102,10 +99,9 @@ public static class StatusEndpoints
                  .DownloadStatusChanged(correlationId, request.State);
 
              return Results.NoContent();
-         })
-         .WithName("UpdateDownloadStatus")
-         .WithSummary("Update download status (worker callback)")
-         .WithOpenApi();
+          })
+          .WithName("UpdateDownloadStatus")
+          .WithSummary("Update download status (worker callback)");
 
         // POST /api/downloads/{correlationId}/progress - Worker progress callback
         group.MapPost("/{correlationId}/progress", async (
@@ -145,8 +141,7 @@ public static class StatusEndpoints
             return Results.NoContent();
         })
         .WithName("UpdateDownloadProgress")
-        .WithSummary("Update download progress (worker callback)")
-        .WithOpenApi();
+        .WithSummary("Update download progress (worker callback)");
 
         // GET /api/metrics - System metrics
         app.MapGet("/api/metrics", async (
@@ -181,8 +176,7 @@ public static class StatusEndpoints
             return Results.Ok(response);
         })
         .WithName("GetMetrics")
-        .WithSummary("Get system metrics")
-        .WithOpenApi();
+        .WithSummary("Get system metrics");
     }
 
     private static DownloadStatusResponse MapToResponse(DownloadStatusRecord status)

--- a/src/Cutube.Worker/Cutube.Worker.csproj
+++ b/src/Cutube.Worker/Cutube.Worker.csproj
@@ -12,8 +12,10 @@
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.3" />
-    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- aligns Worker logging packages with hosted-service usage by replacing `Serilog.AspNetCore` with `Serilog.Extensions.Hosting` and adding configuration/console sink packages
- removes deprecated `.WithOpenApi()` calls from status endpoints to eliminate ASPDEPR002 warnings
- removes redundant `System.Net.Http.Json` reference from CLI project

## Why
- closes remaining warning debt blocking phase 5.3 completion criteria
- keeps resilience/observability improvements shippable under clean quality gates

## Validation
- `dotnet test` passed: 173 passed, 1 skipped, 0 failed
- `dotnet build` passed: 0 warnings, 0 errors

## Scope
- `src/Cutube.Worker/Cutube.Worker.csproj`
- `src/Cutube.Api/Endpoints/StatusEndpoints.cs`
- `cutube/cutube.csproj`

## Notes
- commits are atomic and separated by concern (worker packages, API deprecation cleanup, CLI package cleanup)
- base branch is `develop` (repository does not have a `dev` branch)