### PR TITLE
feat(docker): add Dockerfiles for monorepo structure (Cutube-vxo.17)

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,0 +1,53 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+# Copy solution and restore
+COPY cutube.sln ./
+COPY src/Cutube.Api/Cutube.Api.csproj src/Cutube.Api/
+COPY src/Cutube.Contracts/Cutube.Contracts.csproj src/Cutube.Contracts/
+COPY src/Cutube.Domain/Cutube.Domain.csproj src/Cutube.Domain/
+COPY src/Cutube.Application/Cutube.Application.csproj src/Cutube.Application/
+COPY src/Cutube.Core/Cutube.Core.csproj src/Cutube.Core/
+COPY src/Cutube.Infrastructure/Cutube.Infrastructure.csproj src/Cutube.Infrastructure/
+RUN dotnet restore src/Cutube.Api/Cutube.Api.csproj
+
+# Copy source and build
+COPY src/Cutube.Api/ src/Cutube.Api/
+COPY src/Cutube.Contracts/ src/Cutube.Contracts/
+COPY src/Cutube.Domain/ src/Cutube.Domain/
+COPY src/Cutube.Application/ src/Cutube.Application/
+COPY src/Cutube.Core/ src/Cutube.Core/
+COPY src/Cutube.Infrastructure/ src/Cutube.Infrastructure/
+RUN dotnet publish src/Cutube.Api/Cutube.Api.csproj -c Release -o /app/publish
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS runtime
+WORKDIR /app
+
+# Install runtime dependencies
+RUN apk add --no-cache \
+    curl \
+    ffmpeg \
+    deno \
+    python3 \
+    py3-pip
+
+# Install yt-dlp
+RUN pip3 install --no-cache-dir --break-system-packages yt-dlp
+
+# Copy published app
+COPY --from=build /app/publish .
+
+# Create downloads directory
+RUN mkdir -p /app/downloads
+
+# Expose ports
+EXPOSE 8080 8081
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+    CMD curl -f http://localhost:8080/health || exit 1
+
+# Run
+ENTRYPOINT ["dotnet", "Cutube.Api.dll"]

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,0 +1,44 @@
+# Build stage
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+# Copy package files
+COPY src/Cutube.Web/package*.json ./
+
+# Install dependencies
+RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
+
+# Copy source
+COPY src/Cutube.Web/ ./
+
+# Build
+ARG API_INTERNAL_URL
+ENV API_INTERNAL_URL=${API_INTERNAL_URL}
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN npm run build
+
+# Production stage
+FROM node:20-alpine AS runtime
+
+WORKDIR /app
+
+# Copy necessary files
+COPY --from=build /app/package*.json ./
+COPY --from=build /app/.next ./.next
+COPY --from=build /app/public ./public
+COPY --from=build /app/node_modules ./node_modules
+
+# Environment
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=4000
+
+EXPOSE 4000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+    CMD wget -q --spider http://localhost:4000 || exit 1
+
+# Run
+CMD ["npm", "start"]

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -9,8 +9,21 @@ COPY src/Cutube.Web/package*.json ./
 # Install dependencies
 RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
 
-# Copy source
-COPY src/Cutube.Web/ ./
+# Copy source (excluding node_modules via .dockerignore in build context)
+COPY src/Cutube.Web/app ./app
+COPY src/Cutube.Web/components ./components
+COPY src/Cutube.Web/hooks ./hooks
+COPY src/Cutube.Web/lib ./lib
+COPY src/Cutube.Web/types ./types
+COPY src/Cutube.Web/public ./public
+COPY src/Cutube.Web/next.config.ts ./
+COPY src/Cutube.Web/next-env.d.ts ./
+COPY src/Cutube.Web/tsconfig.json ./
+COPY src/Cutube.Web/components.json ./
+COPY src/Cutube.Web/.prettierrc.json ./
+COPY src/Cutube.Web/eslint.config.mjs ./
+COPY src/Cutube.Web/postcss.config.mjs ./
+COPY src/Cutube.Web/tailwind.config.ts ./
 
 # Build
 ARG API_INTERNAL_URL

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -1,0 +1,46 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+# Copy solution and restore
+COPY cutube.sln ./
+COPY src/Cutube.Worker/Cutube.Worker.csproj src/Cutube.Worker/
+COPY src/Cutube.Contracts/Cutube.Contracts.csproj src/Cutube.Contracts/
+COPY src/Cutube.Application/Cutube.Application.csproj src/Cutube.Application/
+COPY src/Cutube.Core/Cutube.Core.csproj src/Cutube.Core/
+RUN dotnet restore src/Cutube.Worker/Cutube.Worker.csproj
+
+# Copy source and build
+COPY src/Cutube.Worker/ src/Cutube.Worker/
+COPY src/Cutube.Contracts/ src/Cutube.Contracts/
+COPY src/Cutube.Application/ src/Cutube.Application/
+COPY src/Cutube.Core/ src/Cutube.Core/
+RUN dotnet publish src/Cutube.Worker/Cutube.Worker.csproj -c Release -o /app/publish -p:ErrorOnDuplicatePublishOutputFiles=false
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/runtime:10.0-alpine AS runtime
+WORKDIR /app
+
+# Install dependencies
+RUN apk add --no-cache \
+    ffmpeg \
+    deno \
+    python3 \
+    py3-pip \
+    curl
+
+# Install yt-dlp
+RUN pip3 install --no-cache-dir --break-system-packages yt-dlp
+
+# Copy published app
+COPY --from=build /app/publish .
+
+# Create downloads directory
+RUN mkdir -p /downloads
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+    CMD [ -f /tmp/cutube-worker-health ] && [ "$(cat /tmp/cutube-worker-health)" = "healthy" ] || exit 1
+
+# Run
+ENTRYPOINT ["dotnet", "Cutube.Worker.dll"]


### PR DESCRIPTION
## Summary
Adds three Dockerfiles (API, Web, Worker) configured for the new monorepo structure with multi-stage builds, health checks, and proper runtime dependencies.

## Key Changes
- Add docker/Dockerfile.api with .NET 10 SDK/ASP.NET runtime, ffmpeg, deno, yt-dlp (docker/Dockerfile.api)
- Add docker/Dockerfile.web with Node.js 20 Alpine and Next.js production build (docker/Dockerfile.web)
- Add docker/Dockerfile.worker with .NET 10 runtime and media processing dependencies (docker/Dockerfile.worker)

## Quality
Tests passing: 431 tests
Skipped: 1 test (requires special OS permissions - justified)
Build: Succeeded (1 non-blocking warning)
Code review: No blocking issues

## Notes
All Dockerfiles use multi-stage builds for optimal image size. Health checks implemented on ports 8080/8081 (API), 4000 (Web), and file-based (Worker). Runtime dependencies include ffmpeg, deno, python3, and yt-dlp for media processing.